### PR TITLE
feat: add Subscriber 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,8 +81,8 @@ linters-settings:
 
   gocognit:
     # Minimal code complexity to report.
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 20
+    # Default: 30
+    min-complexity: 25
 
   gocritic:
     # Settings passed to gocritic.

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -35,6 +35,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/nats-io/nats.go"
 	storagev1alpha1 "github.com/rancher/sbombastic/api/storage/v1alpha1"
 	"github.com/rancher/sbombastic/api/v1alpha1"
 	"github.com/rancher/sbombastic/internal/controller"
@@ -90,6 +91,12 @@ func main() {
 	js, err := messaging.NewJetStreamContext(ns)
 	if err != nil {
 		setupLog.Error(err, "unable to create JetStream context")
+		os.Exit(1)
+	}
+
+	err = messaging.AddStream(js, nats.FileStorage)
+	if err != nil {
+		setupLog.Error(err, "unable to add JetStream stream")
 		os.Exit(1)
 	}
 

--- a/internal/messaging/handler.go
+++ b/internal/messaging/handler.go
@@ -1,0 +1,6 @@
+package messaging
+
+type Handler interface {
+	Handle(msg Message) error
+	NewMessage() Message
+}

--- a/internal/messaging/publisher.go
+++ b/internal/messaging/publisher.go
@@ -34,7 +34,7 @@ func (p *publisher) Publish(message Message) error {
 	header.Add(MessageTypeHeader, message.MessageType())
 
 	msg := &nats.Msg{
-		Subject: SbombasticSubject,
+		Subject: sbombasticSubject,
 		Data:    data,
 		Header:  header,
 	}

--- a/internal/messaging/publisher_test.go
+++ b/internal/messaging/publisher_test.go
@@ -5,17 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type testMessage struct {
-	Data string `json:"data"`
-}
-
-func (m testMessage) MessageType() string {
-	return "test-type"
-}
 
 func TestPublisher_Publish(t *testing.T) {
 	ns, err := NewServer()
@@ -23,6 +16,9 @@ func TestPublisher_Publish(t *testing.T) {
 	defer ns.Shutdown()
 
 	js, err := NewJetStreamContext(ns)
+	require.NoError(t, err)
+
+	err = AddStream(js, nats.MemoryStorage)
 	require.NoError(t, err)
 
 	publisher := NewPublisher(js)
@@ -34,7 +30,7 @@ func TestPublisher_Publish(t *testing.T) {
 	err = publisher.Publish(msg)
 	require.NoError(t, err)
 
-	sub, err := js.SubscribeSync(SbombasticSubject)
+	sub, err := js.SubscribeSync(sbombasticSubject)
 	require.NoError(t, err)
 	defer func() {
 		err := sub.Unsubscribe()

--- a/internal/messaging/subscriber.go
+++ b/internal/messaging/subscriber.go
@@ -1,0 +1,87 @@
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
+)
+
+type HandlerRegistry map[string]Handler
+
+type Subscriber struct {
+	sub      *nats.Subscription
+	handlers HandlerRegistry
+	logger   *zap.Logger
+}
+
+func NewSubscriber(sub *nats.Subscription, handlers HandlerRegistry, logger *zap.Logger) *Subscriber {
+	return &Subscriber{
+		sub:      sub,
+		handlers: handlers,
+		logger:   logger,
+	}
+}
+
+func (s *Subscriber) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("Subscriber shutting down...")
+
+			return nil
+		default:
+			msgs, err := s.sub.Fetch(1, nats.MaxWait(5*time.Second))
+			if err != nil {
+				if errors.Is(err, nats.ErrTimeout) {
+					continue
+				}
+
+				return fmt.Errorf("failed to fetch message: %w", err)
+			}
+
+			for _, msg := range msgs {
+				s.logger.Debug("Processing message", zap.Any("message", msg))
+				if err := s.processMessage(msg); err != nil {
+					s.logger.Error("Failed to process message",
+						zap.Error(err),
+						zap.String("subject", msg.Subject),
+						zap.Any("header", msg.Header),
+						zap.ByteString("data", msg.Data))
+				}
+
+				if err := msg.Ack(); err != nil {
+					return fmt.Errorf("failed to ack message: %w", err)
+				}
+			}
+		}
+	}
+}
+
+// processMessage handles individual message processing.
+func (s *Subscriber) processMessage(msg *nats.Msg) error {
+	msgType := msg.Header.Get(MessageTypeHeader)
+	if msgType == "" {
+		return fmt.Errorf("malformed message: missing type header, header: %v", msg.Header)
+	}
+
+	handler, found := s.handlers[msgType]
+	if !found {
+		return fmt.Errorf("no handler found for message type: %s", msgType)
+	}
+
+	message := handler.NewMessage()
+	if err := json.Unmarshal(msg.Data, message); err != nil {
+		return fmt.Errorf("failed to unmarshal message of type %s: %w", msgType, err)
+	}
+
+	if err := handler.Handle(message); err != nil {
+		return fmt.Errorf("failed to handle message of type %s: %w", msgType, err)
+	}
+
+	return nil
+}

--- a/internal/messaging/subscriber_test.go
+++ b/internal/messaging/subscriber_test.go
@@ -1,0 +1,177 @@
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+type testHandler struct {
+	handleFunc func(Message) error
+}
+
+func (h *testHandler) Handle(message Message) error {
+	return h.handleFunc(message)
+}
+
+func (h *testHandler) NewMessage() Message {
+	return &testMessage{}
+}
+
+func TestSubscriber_Run(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	ns, err := NewServer()
+	require.NoError(t, err)
+	defer ns.Shutdown()
+
+	js, err := NewJetStreamContext(ns)
+	require.NoError(t, err)
+
+	err = AddStream(js, nats.MemoryStorage)
+	require.NoError(t, err)
+
+	sub, err := NewSubscription(ns.ClientURL(), "test-sub")
+	require.NoError(t, err)
+
+	message := &testMessage{Data: "data"}
+	header := nats.Header{MessageTypeHeader: {"test-type"}}
+
+	processed := make(chan Message, 1)
+	done := make(chan struct{})
+
+	handleFunc := func(m Message) error {
+		processed <- m
+		return nil
+	}
+
+	testHandler := &testHandler{handleFunc: handleFunc}
+	handlers := HandlerRegistry{
+		"test-type": testHandler,
+	}
+	subscriber := NewSubscriber(sub, handlers, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	data, err := json.Marshal(message)
+	require.NoError(t, err, "failed to marshal testMessage data")
+
+	msg := &nats.Msg{
+		Subject: sbombasticSubject,
+		Data:    data,
+		Header:  header,
+	}
+
+	_, err = js.PublishMsg(msg)
+	require.NoError(t, err, "failed to publish message")
+
+	go func() {
+		err = subscriber.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case processedMessage := <-processed:
+		require.Equal(t, message, processedMessage, "unexpected message")
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timed out waiting for message to be processed")
+	}
+
+	cancel()
+	<-done
+
+	require.NoError(t, err, "unexpected subscriber error")
+}
+
+func TestProcessMessage(t *testing.T) {
+	logger := zaptest.NewLogger(t) // Use zaptest for logger
+
+	tests := []struct {
+		name          string
+		msg           *nats.Msg
+		handleFunc    func(Message) error
+		expectedError string
+	}{
+		{
+			name: "valid message",
+			msg: &nats.Msg{
+				Subject: sbombasticSubject,
+				Data:    []byte(`{"data":"valid"}`),
+				Header:  nats.Header{MessageTypeHeader: {"test-type"}},
+			},
+			handleFunc: func(_ Message) error {
+				return nil
+			},
+			expectedError: "",
+		},
+		{
+			name: "missing type header",
+			msg: &nats.Msg{
+				Subject: sbombasticSubject,
+				Data:    []byte(`{"data":"valid"}`),
+				Header:  nats.Header{},
+			},
+			expectedError: "malformed message: missing type header",
+		},
+		{
+			name: "unknown message type",
+			msg: &nats.Msg{
+				Subject: sbombasticSubject,
+				Data:    []byte(`{"data":"valid"}`),
+				Header:  nats.Header{MessageTypeHeader: {"unknown-type"}},
+			},
+			expectedError: "no handler found for message type: unknown-type",
+		},
+		{
+			name: "invalid message format",
+			msg: &nats.Msg{
+				Subject: sbombasticSubject,
+				Data:    []byte(`{"invalid-json"`),
+				Header:  nats.Header{MessageTypeHeader: {"test-type"}},
+			},
+			expectedError: "failed to unmarshal message of type test-type",
+		},
+		{
+			name: "handler failure",
+			msg: &nats.Msg{
+				Subject: sbombasticSubject,
+				Data:    []byte(`{"data":"valid"}`),
+				Header:  nats.Header{MessageTypeHeader: {"test-type"}},
+			},
+			handleFunc: func(_ Message) error {
+				return errors.New("handler error")
+			},
+			expectedError: "failed to handle message of type test-type: handler error",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handlers := HandlerRegistry{}
+			handlers["test-type"] = &testHandler{
+				handleFunc: test.handleFunc,
+			}
+
+			subscriber := &Subscriber{
+				handlers: handlers,
+				logger:   logger,
+			}
+
+			err := subscriber.processMessage(test.msg)
+
+			if test.expectedError == "" {
+				require.NoError(t, err, "expected no error, got: %v", err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedError, "expected error message does not match")
+			}
+		})
+	}
+}

--- a/internal/messaging/types_test.go
+++ b/internal/messaging/types_test.go
@@ -1,0 +1,9 @@
+package messaging
+
+type testMessage struct {
+	Data string `json:"data"`
+}
+
+func (m testMessage) MessageType() string {
+	return "test-type"
+}


### PR DESCRIPTION
This PR adds a subscriber that allows us to receive messages from the NATS worker queue and send them to the right handler.

A handler is any type that uses the Handle interface and can be added to the subscriber when it is created. Each handler is responsible for processing a single kind of message (job).

A follow-up PR will update the Cataloger as well.