### PR TITLE
fix(storage): tryUpdate should only retry index conflict errors

### DIFF
--- a/examples/image.yaml
+++ b/examples/image.yaml
@@ -1,11 +1,8 @@
 apiVersion: storage.sbombastic.rancher.io/v1alpha1
 kind: Image
 metadata:
-  creationTimestamp: "2024-11-15T16:02:47Z"
   name: 82df15a51db0bb0182ee86c6d084c43d1c2731e36c68900ee59c88747dd4af10
   namespace: default
-  resourceVersion: "1"
-  uid: be4efbf7-feb9-4952-8a7f-04ec03c89c9b
 spec:
   imageMetadata:
     digest: sha256:6169c4bcc1982095067d85edf58fdcc3bd8505aef728610c5b728f3cf1cec46b

--- a/examples/sbom.yaml
+++ b/examples/sbom.yaml
@@ -1,11 +1,8 @@
 apiVersion: storage.sbombastic.rancher.io/v1alpha1
 kind: SBOM
 metadata:
-  creationTimestamp: "2024-11-15T16:02:50Z"
   name: 82df15a51db0bb0182ee86c6d084c43d1c2731e36c68900ee59c88747dd4af10
   namespace: default
-  resourceVersion: "1"
-  uid: 81f04e99-82ed-4d7b-95ef-434dc0757e25
 spec:
   imageMetadata:
     digest: sha256:6169c4bcc1982095067d85edf58fdcc3bd8505aef728610c5b728f3cf1cec46b

--- a/examples/vulnerabilityreport.yaml
+++ b/examples/vulnerabilityreport.yaml
@@ -1,11 +1,8 @@
 apiVersion: storage.sbombastic.rancher.io/v1alpha1
 kind: VulnerabilityReport
 metadata:
-  creationTimestamp: "2024-11-15T16:02:54Z"
   name: 82df15a51db0bb0182ee86c6d084c43d1c2731e36c68900ee59c88747dd4af10
   namespace: default
-  resourceVersion: "1"
-  uid: 946d1a07-7775-4824-a656-a74e5255225f
 spec:
   imageMetadata:
     digest: sha256:6169c4bcc1982095067d85edf58fdcc3bd8505aef728610c5b728f3cf1cec46b


### PR DESCRIPTION
The GuaranteedUpdate function receives a tryUpdate function as a parameter. According to the documentation, the update is retried indefinitely only when an index conflict error occurs. However, we were also retrying indefinitely for other errors, leading to an infinite loop.

This PR fixes that issue.