### PR TITLE
fix(storage): return key exists error instead of bubbling up a SQL error

### DIFF
--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -69,6 +69,9 @@ func (suite *storeTestSuite) TestCreate() {
 
 	suite.EqualValues(sbom, out)
 	suite.Equal("1", out.ResourceVersion)
+
+	err = suite.store.Create(context.Background(), key, sbom, out, 0)
+	suite.Require().Equal(storage.NewKeyExistsError(key, 0).Error(), err.Error())
 }
 
 func (suite *storeTestSuite) TestDelete() {


### PR DESCRIPTION
Return key exists error instead of bubbling up a SQL error.