### PR TITLE
fix: improve the logic of handlers to cover scenarios where resources already exist

### DIFF
--- a/internal/handlers/generate_sbom.go
+++ b/internal/handlers/generate_sbom.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	trivyCommands "github.com/aquasecurity/trivy/pkg/commands"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -105,7 +106,9 @@ func (h *GenerateSBOMHandler) Handle(message messaging.Message) error {
 		},
 	}
 	if err := h.k8sClient.Create(ctx, sbom); err != nil {
-		return fmt.Errorf("failed to create SBOM: %w", err)
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create SBOM: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
improve the logic of handlers to cover scenarios where resources already exist

- `CreateCatalogHandler`: skip creation if an `Image` already exists, delete obsolete images.
- `GenerateSBOMHandler`: skip creation if a `SBOM` already exists
- `ScanSBOMHandler`: create or update `VulnerabilityReport`