### PR TITLE
fix(controller): add spec.imageMetadata.registry index to SBOM and Image

### DIFF
--- a/internal/controller/image_controller.go
+++ b/internal/controller/image_controller.go
@@ -78,6 +78,17 @@ func (r *ImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Add an indexer for the field `spec.imageMetadata.registry`
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &storagev1alpha1.Image{}, "spec.imageMetadata.registry", func(rawObj client.Object) []string {
+		sbom, ok := rawObj.(*storagev1alpha1.Image)
+		if !ok {
+			panic(fmt.Sprintf("Expected Image, got %T", rawObj))
+		}
+		return []string{sbom.Spec.ImageMetadata.Registry}
+	}); err != nil {
+		return fmt.Errorf("unable to create field indexer: %w", err)
+	}
+
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&storagev1alpha1.Image{}).
 		Complete(r)

--- a/internal/controller/sbom_controller.go
+++ b/internal/controller/sbom_controller.go
@@ -123,6 +123,17 @@ func (r *SBOMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SBOMReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Add an indexer for the field `spec.imageMetadata.registry`
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &storagev1alpha1.SBOM{}, "spec.imageMetadata.registry", func(rawObj client.Object) []string {
+		sbom, ok := rawObj.(*storagev1alpha1.SBOM)
+		if !ok {
+			panic(fmt.Sprintf("Expected SBOM, got %T", rawObj))
+		}
+		return []string{sbom.Spec.ImageMetadata.Registry}
+	}); err != nil {
+		return fmt.Errorf("unable to create field indexer: %w", err)
+	}
+
 	err := ctrl.NewControllerManagedBy(mgr).
 		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
 		For(&storagev1alpha1.SBOM{}).


### PR DESCRIPTION
Adds `spec.imageMetadata.registry` index  to fix the error: "Index with name field:spec.imageMetadata.registry does not exist" when using field selectors.