### PR TITLE
feat(worker): set owner references

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	handlers := messaging.HandlerRegistry{
 		messaging.CreateCatalogType: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, logger),
-		messaging.GenerateSBOMType:  handlers.NewGenerateSBOMHandler(k8sClient, "/var/run/worker", logger),
+		messaging.GenerateSBOMType:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, "/var/run/worker", logger),
 		messaging.ScanSBOMType:      handlers.NewScanSBOMHandler(k8sClient, "/var/run/worker", logger),
 	}
 	subscriber := messaging.NewSubscriber(sub, handlers, logger)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	handlers := messaging.HandlerRegistry{
-		messaging.CreateCatalogType: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, logger),
+		messaging.CreateCatalogType: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, logger),
 		messaging.GenerateSBOMType:  handlers.NewGenerateSBOMHandler(k8sClient, "/var/run/worker", logger),
 		messaging.ScanSBOMType:      handlers.NewScanSBOMHandler(k8sClient, "/var/run/worker", logger),
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -57,7 +57,7 @@ func main() {
 	handlers := messaging.HandlerRegistry{
 		messaging.CreateCatalogType: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, logger),
 		messaging.GenerateSBOMType:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, "/var/run/worker", logger),
-		messaging.ScanSBOMType:      handlers.NewScanSBOMHandler(k8sClient, "/var/run/worker", logger),
+		messaging.ScanSBOMType:      handlers.NewScanSBOMHandler(k8sClient, scheme, "/var/run/worker", logger),
 	}
 	subscriber := messaging.NewSubscriber(sub, handlers, logger)
 

--- a/internal/handlers/generate_sbom_test.go
+++ b/internal/handlers/generate_sbom_test.go
@@ -57,7 +57,7 @@ func TestGenerateSBOMHandler_Handle(t *testing.T) {
 	err = json.Unmarshal(spdxData, expectedSPDX)
 	require.NoError(t, err)
 
-	handler := NewGenerateSBOMHandler(k8sClient, "/tmp", zap.NewNop())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", zap.NewNop())
 
 	err = handler.Handle(&messaging.GenerateSBOM{
 		ImageName:      image.Name,
@@ -72,7 +72,8 @@ func TestGenerateSBOMHandler_Handle(t *testing.T) {
 	}, sbom)
 	require.NoError(t, err)
 
-	require.Equal(t, image.Spec.ImageMetadata, sbom.Spec.ImageMetadata)
+	assert.Equal(t, image.Spec.ImageMetadata, sbom.Spec.ImageMetadata)
+	assert.Equal(t, image.UID, sbom.GetOwnerReferences()[0].UID)
 
 	generatedSPDX := &spdx.Document{}
 	err = json.Unmarshal(sbom.Spec.SPDX.Raw, generatedSPDX)

--- a/internal/handlers/scan_sbom_test.go
+++ b/internal/handlers/scan_sbom_test.go
@@ -53,7 +53,7 @@ func TestScanSBOMHandler_Handle(t *testing.T) {
 	err = json.Unmarshal(reportData, expectedReport)
 	require.NoError(t, err)
 
-	handler := NewScanSBOMHandler(k8sClient, "/tmp", zap.NewNop())
+	handler := NewScanSBOMHandler(k8sClient, scheme, "/tmp", zap.NewNop())
 
 	err = handler.Handle(&messaging.ScanSBOM{
 		SBOMName:      sbom.Name,
@@ -67,6 +67,9 @@ func TestScanSBOMHandler_Handle(t *testing.T) {
 		Namespace: sbom.Namespace,
 	}, vulnerabilityReport)
 	require.NoError(t, err)
+
+	assert.Equal(t, sbom.GetImageMetadata(), vulnerabilityReport.GetImageMetadata())
+	assert.Equal(t, sbom.UID, vulnerabilityReport.GetOwnerReferences()[0].UID)
 
 	report := &sarif.Report{}
 	err = json.Unmarshal(vulnerabilityReport.Spec.SARIF.Raw, report)


### PR DESCRIPTION
Set owner references for the resources created by the worker.
This ensures that Kubernetes automatically cleans up all related resources when a registry is deleted.