### PR TITLE
chore: switch to slog

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -39,7 +39,7 @@ local_resource(
     ],
 )
 
-entrypoint = ["/controller"]
+entrypoint = ["/controller", "-log-level=debug"]
 dockerfile = "./hack/Dockerfile.controller.tilt"
 
 load("ext://restart_process", "docker_build_with_restart")

--- a/cmd/storage/main.go
+++ b/cmd/storage/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"log"
+	"log/slog"
 	"os"
 
 	"github.com/jmoiron/sqlx"
@@ -30,6 +31,12 @@ import (
 )
 
 func main() {
+	// TODO: add CLI flags
+	opts := slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &opts)).With("component", "storage")
+
 	db, err := sqlx.Connect("sqlite", "storage.db")
 	if err != nil {
 		log.Fatalln(err)
@@ -40,7 +47,7 @@ func main() {
 	db.MustExec(storage.CreateVulnerabilityReportTableSQL)
 
 	ctx := genericapiserver.SetupSignalContext()
-	options := server.NewWardleServerOptions(os.Stdout, os.Stderr, db)
+	options := server.NewWardleServerOptions(db, logger)
 	cmd := server.NewCommandStartWardleServer(ctx, options)
 	code := cli.Run(cmd)
 	os.Exit(code)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ godebug default=go1.23
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/aquasecurity/trivy v0.57.0
+	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
@@ -15,10 +16,10 @@ require (
 	github.com/nats-io/nats.go v1.37.0
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
+	github.com/owenrumney/go-sarif/v2 v2.3.3
 	github.com/spdx/tools-golang v0.5.5
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
-	go.uber.org/zap v1.27.0
 	k8s.io/apimachinery v0.31.2
 	k8s.io/apiserver v0.31.1
 	k8s.io/client-go v0.31.2
@@ -163,7 +164,6 @@ require (
 	github.com/go-git/go-git/v5 v5.12.0 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
@@ -292,7 +292,6 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/openvex/discovery v0.1.1-0.20240802171711-7c54efc57553 // indirect
 	github.com/openvex/go-vex v0.2.5 // indirect
-	github.com/owenrumney/go-sarif/v2 v2.3.3 // indirect
 	github.com/owenrumney/squealer v1.2.4 // indirect
 	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
@@ -373,6 +372,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.21.0 // indirect

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/jmoiron/sqlx"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,7 +98,7 @@ func (cfg *Config) Complete() CompletedConfig {
 }
 
 // New returns a new instance of WardleServer from the given config.
-func (c completedConfig) New(db *sqlx.DB) (*WardleServer, error) {
+func (c completedConfig) New(db *sqlx.DB, logger *slog.Logger) (*WardleServer, error) {
 	genericServer, err := c.GenericConfig.New("sample-apiserver", genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, fmt.Errorf("error creating generic server: %w", err)
@@ -109,15 +110,15 @@ func (c completedConfig) New(db *sqlx.DB) (*WardleServer, error) {
 
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(v1alpha1.GroupName, Scheme, metav1.ParameterCodec, Codecs)
 
-	imageStore, err := storage.NewImageStore(Scheme, c.GenericConfig.RESTOptionsGetter, db)
+	imageStore, err := storage.NewImageStore(Scheme, c.GenericConfig.RESTOptionsGetter, db, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Image store: %w", err)
 	}
-	sbomStore, err := storage.NewSBOMStore(Scheme, c.GenericConfig.RESTOptionsGetter, db)
+	sbomStore, err := storage.NewSBOMStore(Scheme, c.GenericConfig.RESTOptionsGetter, db, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating SBOM store: %w", err)
 	}
-	vulnerabilityReportStore, err := storage.NewVulnerabilityReport(Scheme, c.GenericConfig.RESTOptionsGetter, db)
+	vulnerabilityReportStore, err := storage.NewVulnerabilityReport(Scheme, c.GenericConfig.RESTOptionsGetter, db, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VulnerabilityReport store: %w", err)
 	}

--- a/internal/handlers/create_catalog_test.go
+++ b/internal/handlers/create_catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"path"
 	"strconv"
@@ -14,8 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
-	"go.uber.org/zap"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
@@ -124,7 +123,7 @@ func TestCreateCatalogHandler_Handle(t *testing.T) {
 		WithRuntimeObjects(registry).
 		Build()
 
-	handler := NewCreateCatalogHandler(mockRegistryClientFactory, k8sClient, scheme, zap.NewNop())
+	handler := NewCreateCatalogHandler(mockRegistryClientFactory, k8sClient, scheme, slog.Default())
 	err = handler.Handle(&messaging.CreateCatalog{
 		RegistryName:      registry.Name,
 		RegistryNamespace: registry.Namespace,
@@ -231,7 +230,7 @@ func TestCataloghandler_DeleteObsoleteImages(t *testing.T) {
 
 	handler := &CreateCatalogHandler{
 		k8sClient: k8sClient,
-		logger:    zap.NewNop(),
+		logger:    slog.Default(),
 	}
 
 	ctx := context.Background()

--- a/internal/handlers/generate_sbom_test.go
+++ b/internal/handlers/generate_sbom_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"github.com/spdx/tools-golang/spdx"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,7 +57,7 @@ func TestGenerateSBOMHandler_Handle(t *testing.T) {
 	err = json.Unmarshal(spdxData, expectedSPDX)
 	require.NoError(t, err)
 
-	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", zap.NewNop())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", slog.Default())
 
 	err = handler.Handle(&messaging.GenerateSBOM{
 		ImageName:      image.Name,

--- a/internal/handlers/scan_sbom_test.go
+++ b/internal/handlers/scan_sbom_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/rancher/sbombastic/pkg/generated/clientset/versioned/scheme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,7 +53,7 @@ func TestScanSBOMHandler_Handle(t *testing.T) {
 	err = json.Unmarshal(reportData, expectedReport)
 	require.NoError(t, err)
 
-	handler := NewScanSBOMHandler(k8sClient, scheme, "/tmp", zap.NewNop())
+	handler := NewScanSBOMHandler(k8sClient, scheme, "/tmp", slog.Default())
 
 	err = handler.Handle(&messaging.ScanSBOM{
 		SBOMName:      sbom.Name,

--- a/internal/messaging/subscriber_test.go
+++ b/internal/messaging/subscriber_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 type testHandler struct {
@@ -25,8 +25,6 @@ func (h *testHandler) NewMessage() Message {
 }
 
 func TestSubscriber_Run(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-
 	ns, err := NewServer()
 	require.NoError(t, err)
 	defer ns.Shutdown()
@@ -55,7 +53,7 @@ func TestSubscriber_Run(t *testing.T) {
 	handlers := HandlerRegistry{
 		"test-type": testHandler,
 	}
-	subscriber := NewSubscriber(sub, handlers, logger)
+	subscriber := NewSubscriber(sub, handlers, slog.Default())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -91,8 +89,6 @@ func TestSubscriber_Run(t *testing.T) {
 }
 
 func TestProcessMessage(t *testing.T) {
-	logger := zaptest.NewLogger(t) // Use zaptest for logger
-
 	tests := []struct {
 		name          string
 		msg           *nats.Msg
@@ -161,7 +157,7 @@ func TestProcessMessage(t *testing.T) {
 
 			subscriber := &Subscriber{
 				handlers: handlers,
-				logger:   logger,
+				logger:   slog.Default(),
 			}
 
 			err := subscriber.processMessage(test.msg)

--- a/internal/storage/image_store.go
+++ b/internal/storage/image_store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/rancher/sbombastic/api/storage/v1alpha1"
@@ -23,7 +24,7 @@ CREATE TABLE IF NOT EXISTS images (
 `
 
 // NewImageStore returns a store registry that will work against API services.
-func NewImageStore(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB) (*registry.Store, error) {
+func NewImageStore(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB, logger *slog.Logger) (*registry.Store, error) {
 	strategy := newImageStrategy(scheme)
 
 	newFunc := func() runtime.Object { return &v1alpha1.Image{} }
@@ -42,6 +43,7 @@ func NewImageStore(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter,
 				table:       "images",
 				newFunc:     newFunc,
 				newListFunc: newListFunc,
+				logger:      logger.With("store", "image"),
 			},
 		},
 		CreateStrategy: strategy,

--- a/internal/storage/sbom_store.go
+++ b/internal/storage/sbom_store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/rancher/sbombastic/api/storage/v1alpha1"
@@ -23,7 +24,7 @@ CREATE TABLE IF NOT EXISTS sboms (
 `
 
 // NewSBOMStore returns a store registry that will work against API services.
-func NewSBOMStore(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB) (*registry.Store, error) {
+func NewSBOMStore(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB, logger *slog.Logger) (*registry.Store, error) {
 	strategy := newSBOMStrategy(scheme)
 
 	newFunc := func() runtime.Object { return &v1alpha1.SBOM{} }
@@ -42,6 +43,7 @@ func NewSBOMStore(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, 
 				table:       "sboms",
 				newFunc:     newFunc,
 				newListFunc: newListFunc,
+				logger:      logger.With("store", "sbom"),
 			},
 		},
 		CreateStrategy: strategy,

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -42,6 +43,7 @@ func (suite *storeTestSuite) SetupTest() {
 		table:       "sboms",
 		newFunc:     func() runtime.Object { return &v1alpha1.SBOM{} },
 		newListFunc: func() runtime.Object { return &v1alpha1.SBOMList{} },
+		logger:      slog.Default(),
 	}
 }
 

--- a/internal/storage/vulnerabilityreport_store.go
+++ b/internal/storage/vulnerabilityreport_store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/rancher/sbombastic/api/storage/v1alpha1"
@@ -23,7 +24,7 @@ CREATE TABLE IF NOT EXISTS vulnerabilityreports (
 `
 
 // NewVulnerabilityReport returns a store registry that will work against API services.
-func NewVulnerabilityReport(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB) (*registry.Store, error) {
+func NewVulnerabilityReport(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB, logger *slog.Logger) (*registry.Store, error) {
 	strategy := newVulnerabilityReportStrategy(scheme)
 
 	newFunc := func() runtime.Object { return &v1alpha1.VulnerabilityReport{} }
@@ -42,6 +43,7 @@ func NewVulnerabilityReport(scheme *runtime.Scheme, optsGetter generic.RESTOptio
 				table:       "vulnerabilityreports",
 				newFunc:     newFunc,
 				newListFunc: newListFunc,
+				logger:      logger.With("store", "vulnerabilityreport"),
 			},
 		},
 		CreateStrategy: strategy,


### PR DESCRIPTION
Change logger from `zap` to `slog`.
Note that we are still using `slog` through `logr` in the controller since this is needed by `controller-runtime`.

Fixes: #33 