### PR TITLE
fix: helm chart labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ generate-controller: manifests  ## Generate code containing DeepCopy, DeepCopyIn
 manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects. We use yq to modify the generated files to match our naming and labels conventions.
 	$(CONTROLLER_GEN) rbac:roleName=controller-role crd webhook paths="./api/v1alpha1"  paths="./internal/controller" output:crd:artifacts:config=helm/templates/crd output:rbac:artifacts:config=helm/templates/controller
 	sed -i 's/controller-role/{{ include "sbombastic.fullname" . }}-controller/' helm/templates/controller/role.yaml
-	sed -i '/metadata:/a\  labels:\n    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}' helm/templates/controller/role.yaml
+	sed -i '/metadata:/a\  labels:\n    {{ include "sbombastic.labels" . | nindent 4 }}\n    app.kubernetes.io/component: controller' helm/templates/controller/role.yaml
 
 .PHONY: generate-storage-test-crd
 generate-storage-test-crd: ## Generate CRD used by the controller tests to access the storage resources. This is needed since storage does not provide CRD, being an API server extension.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Common labels
 */}}
 {{- define "sbombastic.labels" -}}
 helm.sh/chart: {{ include "sbombastic.chart" . }}
+{{ include "sbombastic.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -47,7 +48,6 @@ Selector labels
 {{- define "sbombastic.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "sbombastic.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: {{ .Component | quote }}
 {{- end }}
 
 {{/*

--- a/helm/templates/controller/leader_election_role.yaml
+++ b/helm/templates/controller/leader_election_role.yaml
@@ -4,7 +4,8 @@ kind: Role
 metadata:
   name: {{ include "sbombastic.fullname" . }}-controller-leader-election
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: controller
 rules:
   - apiGroups:
       - ""

--- a/helm/templates/controller/leader_election_rolebinding.yaml
+++ b/helm/templates/controller/leader_election_rolebinding.yaml
@@ -3,7 +3,8 @@ kind: RoleBinding
 metadata:
   name: {{ include "sbombastic.fullname" . }}-controller-leader-election
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/templates/controller/metrics_auth_role.yaml
+++ b/helm/templates/controller/metrics_auth_role.yaml
@@ -3,7 +3,8 @@ kind: ClusterRole
 metadata:
   name: {{ include "sbombastic.fullname" . }}-controller-metrics-auth
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: controller
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/helm/templates/controller/metrics_auth_rolebinding.yaml
+++ b/helm/templates/controller/metrics_auth_rolebinding.yaml
@@ -3,7 +3,8 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "sbombastic.fullname" . }}-controller-metrics-auth
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/templates/controller/metrics_reader_role.yaml
+++ b/helm/templates/controller/metrics_reader_role.yaml
@@ -3,7 +3,8 @@ kind: ClusterRole
 metadata:
   name: {{ include "sbombastic.fullname" . }}-controller-metrics-reader
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: controller
 rules:
 - nonResourceURLs:
   - "/metrics"

--- a/helm/templates/controller/role.yaml
+++ b/helm/templates/controller/role.yaml
@@ -3,7 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
   name: {{ include "sbombastic.fullname" . }}-controller
 rules:
 - apiGroups:

--- a/helm/templates/controller/rolebinding.yaml
+++ b/helm/templates/controller/rolebinding.yaml
@@ -3,7 +3,8 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "sbombastic.fullname" . }}-controller
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/templates/controller/service.yaml
+++ b/helm/templates/controller/service.yaml
@@ -4,12 +4,14 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-controller-nats
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: controller
 spec:
   ports:
     - port: 4222
       protocol: TCP
       targetPort: 4222
   selector:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.selectorLabels" .| nindent 4 }}
+    app.kubernetes.io/component: controller
   type: ClusterIP 

--- a/helm/templates/controller/serviceaccount.yaml
+++ b/helm/templates/controller/serviceaccount.yaml
@@ -4,4 +4,5 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: controller

--- a/helm/templates/controller/statefulset.yaml
+++ b/helm/templates/controller/statefulset.yaml
@@ -4,17 +4,20 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 4 }}
+    {{ include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
 spec:
   selector:
     matchLabels:
-      {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 6 }}
+      {{ include "sbombastic.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
   serviceName: {{ include "sbombastic.fullname" . }}-controller
   replicas: {{ .Values.controller.replicas }}
   template:
     metadata:
       labels:
-        {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 8 }}
+        {{ include "sbombastic.labels" . | nindent 8 }}
+        app.kubernetes.io/component: controller
     spec:
       containers:
         - command:

--- a/helm/templates/storage/apiservice.yaml
+++ b/helm/templates/storage/apiservice.yaml
@@ -3,7 +3,8 @@ kind: APIService
 metadata:
   name: v1alpha1.storage.sbombastic.rancher.io
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: storage
 spec:
   insecureSkipTLSVerify: true
   group: storage.sbombastic.rancher.io

--- a/helm/templates/storage/auth_delegator_rolebinding.yaml
+++ b/helm/templates/storage/auth_delegator_rolebinding.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-storage-auth-delegator
   namespace: kube-system
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: storage
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/templates/storage/auth_reader_rolebinding.yaml
+++ b/helm/templates/storage/auth_reader_rolebinding.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-storage-auth-reader
   namespace: kube-system
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: storage
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/templates/storage/deployment.yaml
+++ b/helm/templates/storage/deployment.yaml
@@ -4,16 +4,19 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-storage
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storage
 spec:
   replicas: {{ .Values.storage.replicas }}
   selector:
     matchLabels:
-      {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 6 }}
+      {{ include "sbombastic.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: storage
   template:
     metadata:
       labels:
-        {{ include "sbombastic.labels" (merge . (dict "Component" "controller")) | nindent 7 }}
+        {{ include "sbombastic.labels" . | nindent 8 }}
+        app.kubernetes.io/component: storage
     spec:
       serviceAccountName: {{ include "sbombastic.fullname" . }}-storage
       containers:

--- a/helm/templates/storage/role.yaml
+++ b/helm/templates/storage/role.yaml
@@ -3,7 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "sbombastic.fullname" . }}-storage
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: storage
 rules:
   - apiGroups: [""]
     resources: ["namespaces"]

--- a/helm/templates/storage/rolebinding.yaml
+++ b/helm/templates/storage/rolebinding.yaml
@@ -3,7 +3,8 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "sbombastic.fullname" . }}-storage
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: storage
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/templates/storage/service.yaml
+++ b/helm/templates/storage/service.yaml
@@ -4,11 +4,13 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-storage
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: storage
 spec:
   ports:
     - port: 443
       protocol: TCP
       targetPort: 443
   selector:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.selectorLabels" .| nindent 4 }}
+    app.kubernetes.io/component: storage

--- a/helm/templates/storage/serviceaccount.yaml
+++ b/helm/templates/storage/serviceaccount.yaml
@@ -4,4 +4,5 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-storage
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "sbombastic.labels" (merge . (dict "Component" "storage")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: storage

--- a/helm/templates/worker/deployment.yaml
+++ b/helm/templates/worker/deployment.yaml
@@ -4,16 +4,19 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-worker
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "sbombastic.labels" (merge . (dict "Component" "worker")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: worker
 spec:
   replicas: {{ .Values.worker.replicas }}
   selector:
     matchLabels:
-      {{- include "sbombastic.selectorLabels" (merge . (dict "Component" "worker")) | nindent 6 }}
+      {{ include "sbombastic.selectorLabels" .| nindent 6 }}
+      app.kubernetes.io/component: worker
   template:
     metadata:
       labels:
-        {{- include "sbombastic.selectorLabels" (merge . (dict "Component" "worker")) | nindent 8 }}
+        {{ include "sbombastic.labels" .| nindent 8 }}
+        app.kubernetes.io/component: worker
     spec:
       serviceAccountName: {{ include "sbombastic.fullname" . }}-worker
       containers:

--- a/helm/templates/worker/role.yaml
+++ b/helm/templates/worker/role.yaml
@@ -3,7 +3,8 @@ kind: ClusterRole
 metadata:
   name: {{ include "sbombastic.fullname" . }}-worker
   labels:
-    {{- include "sbombastic.labels" (merge . (dict "Component" "worker")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: worker
 rules:
   - apiGroups:
       - sbombastic.rancher.io

--- a/helm/templates/worker/rolebinding.yaml
+++ b/helm/templates/worker/rolebinding.yaml
@@ -3,7 +3,8 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "sbombastic.fullname" . }}-worker
   labels:
-    {{- include "sbombastic.labels" (merge . (dict "Component" "worker")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: worker
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/templates/worker/serviceaccount.yaml
+++ b/helm/templates/worker/serviceaccount.yaml
@@ -4,4 +4,5 @@ metadata:
   name: {{ include "sbombastic.fullname" . }}-worker
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "sbombastic.labels" (merge . (dict "Component" "worker")) | nindent 4 }}
+    {{ include "sbombastic.labels" .| nindent 4 }}
+    app.kubernetes.io/component: worker


### PR DESCRIPTION
Resolve an issue in the Helm chart where the labels helper incorrectly set the `app.kubernetes.io/component` label to `worker` for all components.
This issue also caused the storage service to target the controller's pods.
