### PR TITLE
ci: group k8s dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
   schedule:
     interval: "daily"
   open-pull-requests-limit: 10
+  groups:
+    kubernetes:
+      patterns:
+        - "sigs.k8s.io/controller-runtime"
+        - "k8s.io/apimachinery"
+        - "k8s.io/client-go"
+        - "k8s.io/component-base"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Ensure certain kubernetes dependencies are bumped by the same PR, otherwise induvidual PRs are going to fail
