### PR TITLE
chore: fix kubernetes dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,24 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 10
-  groups:
-    kubernetes:
-      patterns:
-        - "sigs.k8s.io/controller-runtime"
-        - "k8s.io/apimachinery"
-        - "k8s.io/client-go"
-        - "k8s.io/component-base"
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-- package-ecosystem: "docker"
-  directory: "/"
-  schedule:
-    interval: "daily"
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/apimachinery"
+          - "k8s.io/client-go"
+          - "k8s.io/apiserver"
+          - "k8s.io/code-generator"
+          - "k8s.io/component-base"
+          - "sigs.k8s.io/controller-runtime"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add the missing `k8s.io/apiserver` and reorder it like go.mod.