### PR TITLE
ci: fix golang ci timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,3 @@ jobs:
         uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
         with:
           version: v1.63.4
-          args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ run:
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
   timeout: 10m
+  concurrency: 4
 
 # This file contains only configs which differ from defaults.
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml


### PR DESCRIPTION
### Summary

- Remove the args in ci.yaml (it override the timeout in .golangci.yml)
- add concurrency in .golangci.yml to improve performance. ([github host runner doc ](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)shows ubuntu-latest, ci env use 4 core, so I set to 4)