### PR TITLE
fix: do not panic when image platform is not set

### DIFF
--- a/internal/handlers/registry/client.go
+++ b/internal/handlers/registry/client.go
@@ -174,6 +174,9 @@ func (c *client) GetImageDetails(ref name.Reference, platform *cranev1.Platform)
 
 	// ensure platform is always set
 	platform = cfgFile.Platform()
+	if platform == nil {
+		return ImageDetails{}, fmt.Errorf("cannot get platform for %s", ref)
+	}
 
 	layers, err := img.Layers()
 	if err != nil {


### PR DESCRIPTION
When the scanner finds an OCI image, it should not panic because the platform is not set.

I think the `nil` handling is required, but we should also avoid to look into the details of something like an OCI artifact, given they are out of scope for SBOMbastic.

I'll create a dedicated issue to keep track of that.
