### PR TITLE
ci: Bump go-version from 1.23 to 1.24.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
         with:
-          version: v1.63.4
+          version: v1.64.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24.1"
       - run: make test
       - name: Upload unit-tests coverage to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24.1"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
         with:


### PR DESCRIPTION
### Why

- https://github.com/rancher-sandbox/sbombastic/pull/114 require the ci env toolchain to be 1.24.1
- https://github.com/golangci/golangci-lint/issues/5225 mentioned from golangci 1.64, support go 1.24, so I upgrade to latest, 1.64.8 (https://github.com/golangci/golangci-lint/issues/5225)