### PR TITLE
fix: add continue to avoid blocking the image generate.

### DIFF
--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -107,7 +107,9 @@ func (h *CreateCatalogHandler) Handle(message messaging.Message) error {
 
 		images, err := h.refToImages(registryClient, ref, registry)
 		if err != nil {
-			return fmt.Errorf("cannot get images for %s: %w", ref, err)
+			h.logger.Error("Error cannot get images for ref", "ref", ref, "error", err)
+			// Avoid blocking other images to be cataloged
+			continue
 		}
 
 		for _, image := range images {

--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -107,7 +107,7 @@ func (h *CreateCatalogHandler) Handle(message messaging.Message) error {
 
 		images, err := h.refToImages(registryClient, ref, registry)
 		if err != nil {
-			h.logger.Error(fmt.Sprintf("cannot get images for %s: %s", ref, err.Error()))
+			h.logger.Info("cannot get images", "reference", ref.String(), "error", err)
 			// Avoid blocking other images to be cataloged
 			continue
 		}
@@ -196,20 +196,20 @@ func (h *CreateCatalogHandler) refToImages(registryClient registryclient.Client,
 			if platform != nil {
 				platformStr = platform.String()
 			}
-			h.logger.Error(fmt.Sprintf("cannot get image details with ref: %s, platform: %s, error: %s", ref.Name(), platformStr, err.Error()))
+			h.logger.Info("cannot get image details", "reference", ref.Name(), "platform", platformStr, "error", err)
 			// Avoid blocking other images to be cataloged
 			continue
 		}
 
 		image, err := imageDetailsToImage(ref, imageDetails, registry)
 		if err != nil {
-			h.logger.Error(fmt.Sprintf("cannot convert image details to image, with error: %s", err.Error()))
+			h.logger.Info("cannot convert image details to image", "reference", ref.Name(), "error", err)
 			// Avoid blocking other images to be cataloged
 			continue
 		}
 
 		if err := controllerutil.SetControllerReference(registry, &image, h.scheme); err != nil {
-			h.logger.Error(fmt.Sprintf("cannot set owner reference, with error: %s", err.Error()))
+			h.logger.Info("cannot set owner reference", "reference", ref.Name(), "error", err)
 			// Avoid blocking other images to be cataloged
 			continue
 		}

--- a/internal/handlers/create_catalog_test.go
+++ b/internal/handlers/create_catalog_test.go
@@ -114,7 +114,7 @@ func TestCreateCatalogHandler_Handle(t *testing.T) {
 
 	mockRegistryClient.On("GetImageDetails", image, &platformLinuxAmd64).Return(imageDetailsLinuxAmd64, nil)
 	mockRegistryClient.On("GetImageDetails", image, &platformLinuxArm64).Return(imageDetailsLinuxArm64, nil)
-	mockRegistryClient.On("GetImageDetails", image, mock.Anything).Return(registry.ImageDetails{}, fmt.Errorf("cannot get platform for %s", image))
+	mockRegistryClient.On("GetImageDetails", image, (*cranev1.Platform)(nil)).Return(registry.ImageDetails{}, fmt.Errorf("cannot get platform for %s", image))
 	mockRegistryClientFactory := func(_ http.RoundTripper) registry.Client { return mockRegistryClient }
 
 	registry := &v1alpha1.Registry{


### PR DESCRIPTION
## Description
Fix https://github.com/rancher-sandbox/sbombastic/issues/121

## Test
Inside of the development environment, with tilt up, create the following registry definition:
```yaml
apiVersion: sbombastic.rancher.io/v1alpha1
kind: Registry
metadata:
  name: kw-controller
  namespace: default
spec:
  uri: ghcr.io
  repositories:
    - kubewarden/kubewarden-controller   
```
The scan succeed, Image resources are created.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->