### PR TITLE
feat: add e2e test for sbombastic

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+bin/
+coverage/
+docs/
+examples/
+helm/
+test/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,15 @@
+name: E2E test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: Run E2E tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: "1.24.1"
+      - run: make test-e2e

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,7 +1,7 @@
 tilt_settings_file = "./tilt-settings.yaml"
 settings = read_yaml(tilt_settings_file)
 
-# Setup a development registry so we can push images to it 
+# Setup a development registry so we can push images to it
 # and use them to test the scanner.
 k8s_yaml('./hack/registry.yaml')
 
@@ -75,7 +75,6 @@ local_resource(
         "go.sum",
         "cmd/storage",
         "api",
-        "internal/admission",
         "internal/apiserver",
         "internal/storage",
         "pkg"

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	modernc.org/sqlite v1.37.0
 	sigs.k8s.io/controller-runtime v0.20.4
+	sigs.k8s.io/e2e-framework v0.6.0
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0
 )
 
@@ -358,6 +359,7 @@ require (
 	github.com/twitchtv/twirp v8.1.3+incompatible // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/vbatts/tar-split v0.11.6 // indirect
+	github.com/vladimirvivien/gexe v0.4.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1925,6 +1925,8 @@ github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0o
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vbatts/tar-split v0.11.6 h1:4SjTW5+PU11n6fZenf2IPoV8/tz3AaYHMWjf23envGs=
 github.com/vbatts/tar-split v0.11.6/go.mod h1:dqKNtesIOr2j2Qv3W/cHjnvk9I8+G7oAkFDFN6TCBEI=
+github.com/vladimirvivien/gexe v0.4.1 h1:W9gWkp8vSPjDoXDu04Yp4KljpVMaSt8IQuHswLDd5LY=
+github.com/vladimirvivien/gexe v0.4.1/go.mod h1:3gjgTqE2c0VyHnU5UOIwk7gyNzZDGulPb/DJPgcw64E=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
@@ -2905,6 +2907,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
+sigs.k8s.io/e2e-framework v0.6.0 h1:p7hFzHnLKO7eNsWGI2AbC1Mo2IYxidg49BiT4njxkrM=
+sigs.k8s.io/e2e-framework v0.6.0/go.mod h1:IREnCHnKgRCioLRmNi0hxSJ1kJ+aAdjEKK/gokcZu4k=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/kustomize/api v0.19.0 h1:F+2HB2mU1MSiR9Hp1NEgoU2q9ItNOaBJl0I4Dlus5SQ=

--- a/helm/templates/storage/deployment.yaml
+++ b/helm/templates/storage/deployment.yaml
@@ -22,15 +22,20 @@ spec:
       containers:
         - name: storage
           image: {{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}
-          {{- if .Values.storage.logLevel }}
           args:
+            - --cert-dir=/certs
+          {{- if .Values.storage.logLevel }}
             - -log-level={{ .Values.storage.logLevel }}
           {{- end }}
           imagePullPolicy: {{ .Values.storage.image.pullPolicy }}
           volumeMounts:
             - name: sqlite-pvc
               mountPath: /data/sqlite/
+            - name: cert-volume
+              mountPath: /certs
       volumes:
         - name: sqlite-pvc
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.storageData.existingClaim }}{{ .Values.persistence.storageData.existingClaim }}{{- else }}{{ template "sbombastic.fullname" . }}-storage-data{{- end }}
+        - name: cert-volume
+          emptyDir: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,7 +8,7 @@ controller:
     tag: v0.1.0-alpha1
     pullPolicy: IfNotPresent
   replicas: 3
-  logLevel: "info"  
+  logLevel: "info"
 
 storage:
   image:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,0 +1,121 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
+
+	storagev1alpha1 "github.com/rancher/sbombastic/api/storage/v1alpha1"
+	v1alpha1 "github.com/rancher/sbombastic/api/v1alpha1"
+)
+
+func EqualReference(img storagev1alpha1.ImageMetadata, registryURI, registryRepository, tag string) bool {
+	return img.RegistryURI == registryURI &&
+		img.Repository == registryRepository &&
+		img.Tag == tag
+}
+
+func TestRegistryCreation(t *testing.T) {
+	releaseName := "sbombastic"
+	registryName := "test-registry"
+	registryURI := "ghcr.io"
+	registryRepository := "rancher-sandbox/sbombastic/test-assets/golang"
+
+	crName := "dfe56d8371e7df15a3dde25c33a78b84b79766de2ab5a5897032019c878b5932"
+
+	f := features.New("Start Registry CR Creation test").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			manager := helm.New(cfg.KubeconfigFile())
+			err := manager.RunInstall(helm.WithName(releaseName),
+				helm.WithNamespace(cfg.Namespace()),
+				helm.WithChart("../../helm"),
+				helm.WithWait(),
+				helm.WithArgs("--set", "controller.image.tag=latest",
+					"--set", "storage.image.tag=latest",
+					"--set", "worker.image.tag=latest"),
+				helm.WithTimeout("3m"))
+
+			require.NoError(t, err, "sbombastic helm chart is not installed correctly")
+
+			err = storagev1alpha1.AddToScheme(cfg.Client().Resources(cfg.Namespace()).GetScheme())
+			require.NoError(t, err)
+
+			err = v1alpha1.AddToScheme(cfg.Client().Resources(cfg.Namespace()).GetScheme())
+			require.NoError(t, err)
+
+			return ctx
+		}).
+		Assess("Create Registry CR", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			registry := &v1alpha1.Registry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      registryName,
+					Namespace: cfg.Namespace(),
+				},
+				Spec: v1alpha1.RegistrySpec{
+					URI:          registryURI,
+					Repositories: []string{registryRepository},
+				},
+			}
+			err := cfg.Client().Resources().Create(ctx, registry)
+			require.NoError(t, err)
+			return ctx
+		}).
+		Assess("Verify the Image is created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			images := storagev1alpha1.ImageList{
+				Items: []storagev1alpha1.Image{
+					{ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: cfg.Namespace()}},
+				},
+			}
+
+			err := wait.For(conditions.New(cfg.Client().Resources()).ResourcesFound(&images))
+			if err != nil {
+				t.Error(err)
+			}
+			return ctx
+		}).
+		Assess("Verify the SPDX SBOM is created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			sboms := storagev1alpha1.SBOMList{
+				Items: []storagev1alpha1.SBOM{
+					{ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: cfg.Namespace()}},
+				},
+			}
+
+			err := wait.For(conditions.New(cfg.Client().Resources()).ResourcesFound(&sboms))
+			if err != nil {
+				t.Error(err)
+			}
+			return ctx
+		}).
+		Assess("Verify the VulnerabilityReport is created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			vulnReports := storagev1alpha1.VulnerabilityReportList{
+				Items: []storagev1alpha1.VulnerabilityReport{
+					{ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: cfg.Namespace()}},
+				},
+			}
+
+			err := wait.For(conditions.New(cfg.Client().Resources()).ResourcesFound(&vulnReports))
+			if err != nil {
+				t.Error(err)
+			}
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			manager := helm.New(cfg.KubeconfigFile())
+			err := manager.RunUninstall(
+				helm.WithName(releaseName),
+				helm.WithNamespace(cfg.Namespace()),
+			)
+			assert.NoError(t, err, "sbombastic helm chart is not deleted correctly")
+			return ctx
+		})
+
+	testenv.Test(t, f.Feature())
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/support/kind"
+)
+
+var (
+	testenv         env.Environment
+	kindClusterName string
+	namespace       string
+	workerImage     = "ghcr.io/rancher-sandbox/sbombastic/worker:latest"
+	controllerImage = "ghcr.io/rancher-sandbox/sbombastic/controller:latest"
+	storageImage    = "ghcr.io/rancher-sandbox/sbombastic/storage:latest"
+)
+
+func TestMain(m *testing.M) {
+	cfg, _ := envconf.NewFromFlags()
+	testenv = env.NewWithConfig(cfg)
+	namespace = envconf.RandomName("sbombastic-e2e-ns", 32)
+	kindClusterName = envconf.RandomName("sbombastic-e2e-cluster", 32)
+
+	testenv.Setup(
+		envfuncs.CreateCluster(kind.NewProvider(), kindClusterName),
+		envfuncs.CreateNamespace(namespace),
+		envfuncs.LoadImageToCluster(kindClusterName, workerImage, "--verbose", "--mode", "direct"),
+		envfuncs.LoadImageToCluster(kindClusterName, controllerImage, "--verbose", "--mode", "direct"),
+		envfuncs.LoadImageToCluster(kindClusterName, storageImage, "--verbose", "--mode", "direct"),
+	)
+
+	testenv.Finish(
+		envfuncs.DestroyCluster(kindClusterName),
+	)
+
+	os.Exit(testenv.Run(m))
+}


### PR DESCRIPTION
## Description

- Fix https://github.com/rancher-sandbox/sbombastic/issues/32
- Support 
  - e2e test in GHA, every 24 hour
  - able to run locally
  - create cluster, namespace, install by helm with local build controller / worker / storage

## Test

- run `make test-e2e`

## Additional Information
### TODO
- [x] release GHA, because we lack of the release flow now
- [ ] image will not be delete if registry CR is deleted, track in this [issue](https://github.com/rancher-sandbox/sbombastic/issues/182).

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
