### PR TITLE
ci: fix codecov report upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,12 @@ jobs:
       - run: make test
       - name: Upload unit-tests coverage to Codecov
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
         with:
           name: unit-tests
           directory: coverage
           flags: unit-tests
           verbose: true
+          token: ${{ secrets.CODECOV_REPO_TOKEN }}
   helm-unittest:
     name: Helm unittest
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: controller storage worker
 
 .PHONY: test
 test: vet ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_DIR) -p path)" go test $$(go list ./... | grep -v /e2e) -race -test.v -coverprofile coverage/test.txt -covermode=atomic
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_DIR) -p path)" go test $$(go list ./... | grep -v /e2e) -race -test.v -coverprofile coverage/cover.out -covermode=atomic
 
 .PHONY: helm-unittest
 helm-unittest:


### PR DESCRIPTION
> **Superseding** https://github.com/rancher-sandbox/sbombastic/pull/159

Things are broken everywhere, both on `main` and on [this branch](https://github.com/rancher-sandbox/sbombastic/pull/159).

Going by steps...

# `main` branch root cause analysis

The name of the coverage file (`test.txt`) is not matching any of the known patterns of codecov. Hence there's nothing to upload. Looking at the known patterns, a good one can be `cover.out)

This can be seen by looking at a run like [this one](https://github.com/rancher-sandbox/sbombastic/actions/runs/14832670041/job/41637102649).

## The original PR from @pohanhuangtw's fork

The correct name of the GHA **organization** secret holding the codecov token is `CODECOV_TOKEN`. See the following screenshot:

![image](https://github.com/user-attachments/assets/896c871e-bc20-4418-b450-955fe0ab4e1c)

However, when the proper combination of code coverage file + token name is used, the token is not reported as valid.

Visiting the [codecov page of the `rancher-sandbox` organization](https://app.codecov.io/gh/rancher-sandbox/) something is odd:

- No upload has been done recently by any of the projects
- There's a banner with a warning message

See the following screenshot:

![image](https://github.com/user-attachments/assets/9a2103b0-a295-41ab-a646-53ed8d85e389)

Given I don't have control over the organization secret, I created a new codecov token just for this repository.
The new token is now used by the GHA that uploads the results, moreover, I've updated the action to use the new syntax to specify the token.

Even after these changes the uploads were still broken. After having looked into the codecov settings for this project, I found out the repo was disabled :open_mouth:

That however wasn't enough to fix it. Looking closer at the results of the coverage upload I realized the workflow was triggered by a PR from a fork.

GitHub Actions Secrets are not accessible from forks:

> Anyone with collaborator access to this repository can use these secrets and variables for actions. They are not passed to workflows that are triggered by a pull request from a fork. 

Because of that, I'm now trying to fix codecov from a PR that originates from the same repository.
