### PR TITLE
chore: update to golangci v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           flags: unit-tests
           verbose: true
           token: ${{ secrets.CODECOV_REPO_TOKEN }}
+
   helm-unittest:
     name: Helm unittest
     runs-on: ubuntu-latest
@@ -36,6 +37,7 @@ jobs:
       - name: Install Helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest
       - run: make helm-unittest
+
   golangci:
     name: Golangci-lint
     runs-on: ubuntu-latest
@@ -45,6 +47,6 @@ jobs:
         with:
           go-version: "1.24.1"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.8
+          version: v2.1.6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,226 +1,51 @@
-# This code is licensed under the terms of the MIT license https://opensource.org/license/mit
-# Copyright (c) 2021 Marat Reymers
+# This file is licensed under the terms of the MIT license https://opensource.org/license/mit
+# Copyright (c) 2021-2025 Marat Reymers
 
-## Golden config for golangci-lint v1.61.0
+## Golden config for golangci-lint v2.1.6
 #
 # This is the best config for golangci-lint based on my experience and opinion.
 # It is very strict, but not extremely strict.
-# Feel free to adapt and change it for your needs.
+# Feel free to adapt it to suit your needs.
+# If this config helps you, please consider keeping a link to this file (see the next comment).
 
-run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 10m
-  concurrency: 4
+# Based on https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322
 
-# This file contains only configs which differ from defaults.
-# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-linters-settings:
-  cyclop:
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 30
-    # The maximal average package complexity.
-    # If it's higher than 0.0 (float) the check is enabled
-    # Default: 0.0
-    package-average: 10.0
+version: "2"
 
-  errcheck:
-    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-type-assertions: true
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 50
 
-  exhaustive:
-    # Program elements to check for exhaustiveness.
-    # Default: [ switch ]
-    check:
-      - switch
-      - map
+formatters:
+  enable:
+    - goimports # checks if the code and import statements are formatted according to the 'goimports' command
+    - golines # checks if code is formatted, and fixes long lines
 
-  exhaustruct:
-    # List of regular expressions to exclude struct packages and their names from checks.
-    # Regular expressions must match complete canonical struct package/name/structname.
-    # Default: []
-    exclude:
-      # std libs
-      - "^net/http.Client$"
-      - "^net/http.Cookie$"
-      - "^net/http.Request$"
-      - "^net/http.Response$"
-      - "^net/http.Server$"
-      - "^net/http.Transport$"
-      - "^net/url.URL$"
-      - "^os/exec.Cmd$"
-      - "^reflect.StructField$"
-      # public libs
-      - "^github.com/Shopify/sarama.Config$"
-      - "^github.com/Shopify/sarama.ProducerMessage$"
-      - "^github.com/mitchellh/mapstructure.DecoderConfig$"
-      - "^github.com/prometheus/client_golang/.+Opts$"
-      - "^github.com/spf13/cobra.Command$"
-      - "^github.com/spf13/cobra.CompletionOptions$"
-      - "^github.com/stretchr/testify/mock.Mock$"
-      - "^github.com/testcontainers/testcontainers-go.+Request$"
-      - "^github.com/testcontainers/testcontainers-go.FromDockerfile$"
-      - "^golang.org/x/tools/go/analysis.Analyzer$"
-      - "^google.golang.org/protobuf/.+Options$"
-      - "^gopkg.in/yaml.v3.Node$"
+    ## you may want to enable
+    #- gci # checks if code and import statements are formatted, with additional rules
+    #- gofmt # checks if the code is formatted according to 'gofmt' command
 
-  funlen:
-    # Checks the number of lines in a function.
-    # If lower than 0, disable the check.
-    # Default: 60
-    lines: 100
-    # Checks the number of statements in a function.
-    # If lower than 0, disable the check.
-    # Default: 40
-    statements: 50
-    # Ignore comments when counting lines.
-    # Default false
-    ignore-comments: true
+    ## disabled
+    #- gofumpt # [replaced by goimports, gofumports is not available yet] checks if code and import statements are formatted, with additional rules
 
-  gocognit:
-    # Minimal code complexity to report.
-    # Default: 30
-    min-complexity: 25
-
-  gocritic:
-    # Settings passed to gocritic.
-    # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
-    settings:
-      captLocal:
-        # Whether to restrict checker to params only.
-        # Default: true
-        paramsOnly: false
-      underef:
-        # Whether to skip (*x).method() calls where x is a pointer receiver.
-        # Default: true
-        skipRecvDeref: false
-
-  gomodguard:
-    blocked:
-      # List of blocked modules.
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    goimports:
+      # A list of prefixes, which, if set, checks import paths
+      # with the given prefixes are grouped after 3rd-party packages.
       # Default: []
-      modules:
-        - github.com/golang/protobuf:
-            recommendations:
-              - google.golang.org/protobuf
-            reason: "see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules"
-        - github.com/satori/go.uuid:
-            recommendations:
-              - github.com/google/uuid
-            reason: "satori's package is not maintained"
-        - github.com/gofrs/uuid:
-            recommendations:
-              - github.com/gofrs/uuid/v5
-            reason: "gofrs' package was not go module before v5"
+      local-prefixes:
+        - github.com/my/project
 
-  govet:
-    # Enable all analyzers.
-    # Default: false
-    enable-all: true
-    # Disable analyzers by name.
-    # Run `go tool vet help` to see all analyzers.
-    # Default: []
-    disable:
-      - fieldalignment # too strict
-    # Settings per analyzer.
-    settings:
-      shadow:
-        # Whether to be strict about shadowing; can be noisy.
-        # Default: false
-        strict: false
-
-  inamedparam:
-    # Skips check for interface methods with only a single parameter.
-    # Default: false
-    skip-single-param: true
-
-  mnd:
-    # List of function patterns to exclude from analysis.
-    # Values always ignored: `time.Date`,
-    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
-    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
-    # Default: []
-    ignored-functions:
-      - args.Error
-      - flag.Arg
-      - flag.Duration.*
-      - flag.Float.*
-      - flag.Int.*
-      - flag.Uint.*
-      - os.Chmod
-      - os.Mkdir.*
-      - os.OpenFile
-      - os.WriteFile
-      - prometheus.ExponentialBuckets.*
-      - prometheus.LinearBuckets
-
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 0
-
-  nolintlint:
-    # Exclude following linters from requiring an explanation.
-    # Default: []
-    allow-no-explanation: [funlen, gocognit, lll]
-    # Enable to require an explanation of nonzero length after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
-
-  perfsprint:
-    # Optimizes into strings concatenation.
-    # Default: true
-    strconcat: false
-
-  rowserrcheck:
-    # database/sql is always checked
-    # Default: []
-    packages:
-      - github.com/jmoiron/sqlx
-
-  sloglint:
-    # Enforce not using global loggers.
-    # Values:
-    # - "": disabled
-    # - "all": report all global loggers
-    # - "default": report only the default slog logger
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
-    # Default: ""
-    no-global: "all"
-    # Enforce using methods that accept a context.
-    # Values:
-    # - "": disabled
-    # - "all": report all contextless calls
-    # - "scope": report only if a context exists in the scope of the outermost function
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
-    # Default: ""
-    context: "scope"
-
-  tenv:
-    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-    # Default: false
-    all: true
+    golines:
+      # Target maximum line length.
+      # Default: 100
+      max-len: 120
 
 linters:
-  disable-all: true
   enable:
-    ## enabled by default
-    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
-    - gosimple # specializes in simplifying a code
-    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # detects when assignments to existing variables are not used
-    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
-    - unused # checks for unused constants, variables, functions and types
-    ## disabled by default
     - asasalint # checks for pass []any as any in variadic func(...any)
     - asciicheck # checks that your code does not contain non-ASCII identifiers
     - bidichk # checks for dangerous unicode character sequences
@@ -228,13 +53,17 @@ linters:
     - canonicalheader # checks whether net/http.Header uses canonical header
     - copyloopvar # detects places where loop variables are copied (Go 1.22+)
     - cyclop # checks function and package cyclomatic complexity
+    - depguard # checks if package imports are in a list of acceptable packages
     - dupl # tool for code clone detection
     - durationcheck # checks for two durations multiplied together
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
     - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
     - exhaustive # checks exhaustiveness of enum switch statements
+    - exptostd # detects functions from golang.org/x/exp/ that can be replaced by std functions
     - fatcontext # detects nested contexts in loops
     - forbidigo # forbids identifiers
+    - funcorder # checks the order of functions, methods, and constructors
     - funlen # tool for detection of long functions
     - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
     - gochecksumtype # checks exhaustiveness on Go "sum types"
@@ -242,10 +71,11 @@ linters:
     - goconst # finds repeated strings that could be replaced by a constant
     - gocritic # provides diagnostics that check for bugs, performance and style issues
     - gocyclo # computes and checks the cyclomatic complexity of functions
-    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
-    - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
     - goprintffuncname # checks that printf-like functions are named with f at the end
     - gosec # inspects source code for security problems
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
+    - ineffassign # detects when assignments to existing variables are not used
     - intrange # finds places where for loops could make use of an integer range
     - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
     - makezero # finds slice declarations with non-zero initial length
@@ -254,6 +84,7 @@ linters:
     - nakedret # finds naked returns in functions greater than a specified function length
     - nestif # reports deeply nested if statements
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
     - noctx # finds sending http request without context.Context
     - nolintlint # reports ill-formed or insufficient nolint directives
@@ -264,29 +95,29 @@ linters:
     - promlinter # checks Prometheus metrics naming via promlint
     - protogetter # reports direct reads from proto message fields when getters should be used
     - reassign # checks that package variables are not reassigned
+    - recvcheck # checks for receiver type consistency
     - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
     - rowserrcheck # checks whether Err of rows is checked successfully
     - sloglint # ensure consistent code style when using log/slog
     - spancheck # checks for mistakes with OpenTelemetry/Census spans
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
-    - stylecheck # is a replacement for golint
-    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
     - testableexamples # checks if examples are testable (have an expected output)
     - testifylint # checks usage of github.com/stretchr/testify
     - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
     - unconvert # removes unnecessary type conversions
     - unparam # reports unused function parameters
+    - unused # checks for unused constants, variables, functions and types
     - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - usetesting # reports uses of functions with replacement inside the testing package
     - wastedassign # finds wasted assignment statements
     - whitespace # detects leading and trailing whitespace
-    - wrapcheck # checks that errors returned from external packages are wrapped
 
     ## you may want to enable
     #- decorder # checks declaration order and count of types, constants, variables and functions
     #- exhaustruct # [highly recommend to enable] checks if all structure fields are initialized
-    #- gci # controls golang package import order and makes it always deterministic
     #- ginkgolinter # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
-    #- godox # detects FIXME, TODO and other comment keywords
+    #- godox # detects usage of FIXME, TODO and other keywords inside comments
     #- goheader # checks is file header matches to pattern
     #- inamedparam # [great idea, but too strict, need to ignore a lot of cases by default] reports interfaces with unnamed method parameters
     #- interfacebloat # checks the number of methods inside an interface
@@ -294,24 +125,22 @@ linters:
     #- prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
     #- tagalign # checks that struct tags are well aligned
     #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    #- wrapcheck # checks that errors returned from external packages are wrapped
     #- zerologlint # detects the wrong usage of zerolog that a user forgets to dispatch zerolog.Event
 
     ## disabled
     #- containedctx # detects struct contained context.Context field
     #- contextcheck # [too many false positives] checks the function whether use a non-inherited context
-    #- depguard # [replaced by gomodguard] checks if package imports are in a list of acceptable packages
     #- dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
     #- dupword # [useless without config] checks for duplicate words in the source code
     #- err113 # [too strict] checks the errors handling expressions
     #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
-    #- execinquery # [deprecated] checks query string in Query function which reads your Go src files and warning it finds
-    #- exportloopref # [not necessary from Go 1.22] checks for pointers to enclosing loop variables
     #- forcetypeassert # [replaced by errcheck] finds forced type assertions
-    #- gofmt # [replaced by goimports] checks whether code was gofmt-ed
-    #- gofumpt # [replaced by goimports, gofumports is not available yet] checks whether code was gofumpt-ed
+    #- gomodguard # [use more powerful depguard] allow and block lists linter for direct Go module dependencies
     #- gosmopolitan # reports certain i18n/l10n anti-patterns in your Go codebase
     #- grouper # analyzes expression groups
     #- importas # enforces consistent import aliases
+    #- lll # [replaced by golines] reports long lines
     #- maintidx # measures the maintainability index of each function
     #- misspell # [useless] finds commonly misspelled English words in comments
     #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
@@ -350,25 +179,290 @@ linters:
     # This is annoying.
     # - godot # checks if comments end in a period
 
-issues:
-  # Maximum count of issues with the same text.
-  # Set to 0 to disable.
-  # Default: 3
-  max-same-issues: 50
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    cyclop:
+      # The maximal code complexity to report.
+      # Default: 10
+      max-complexity: 30
+      # The maximal average package complexity.
+      # If it's higher than 0.0 (float) the check is enabled.
+      # Default: 0.0
+      package-average: 10.0
 
-  exclude-rules:
-    - source: "(noinspection|TODO)"
-      linters: [godot]
-    - source: "//noinspection"
-      linters: [gocritic]
-    - path: "_test\\.go"
-      linters:
-        - bodyclose
-        - dupl
-        - funlen
-        - goconst
-        - gosec
-        - noctx
-        - wrapcheck
-    - text: 'shadow: declaration of "(err|ctx)" shadows declaration at'
-      linters: [govet]
+    depguard:
+      # Rules to apply.
+      #
+      # Variables:
+      # - File Variables
+      #   Use an exclamation mark `!` to negate a variable.
+      #   Example: `!$test` matches any file that is not a go test file.
+      #
+      #   `$all` - matches all go files
+      #   `$test` - matches all go test files
+      #
+      # - Package Variables
+      #
+      #   `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
+      #
+      # Default (applies if no custom rules are defined): Only allow $gostd in all files.
+      rules:
+        "deprecated":
+          # List of file globs that will match this list of settings to compare against.
+          # By default, if a path is relative, it is relative to the directory where the golangci-lint command is executed.
+          # The placeholder '${base-path}' is substituted with a path relative to the mode defined with `run.relative-path-mode`.
+          # The placeholder '${config-path}' is substituted with a path relative to the configuration file.
+          # Default: $all
+          files:
+            - "$all"
+          # List of packages that are not allowed.
+          # Entries can be a variable (starting with $), a string prefix, or an exact match (if ending with $).
+          # Default: []
+          deny:
+            - pkg: github.com/golang/protobuf
+              desc: Use google.golang.org/protobuf instead, see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+            - pkg: github.com/satori/go.uuid
+              desc: Use github.com/google/uuid instead, satori's package is not maintained
+            - pkg: github.com/gofrs/uuid$
+              desc: Use github.com/gofrs/uuid/v5 or later, it was not a go module before v5
+        "non-test files":
+          files:
+            - "!$test"
+          deny:
+            - pkg: math/rand$
+              desc: Use math/rand/v2 instead, see https://go.dev/blog/randv2
+        "non-main files":
+          files:
+            - "!**/main.go"
+          deny:
+            - pkg: log$
+              desc: Use log/slog instead, see https://go.dev/blog/slog
+
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: true
+
+    exhaustive:
+      # Program elements to check for exhaustiveness.
+      # Default: [ switch ]
+      check:
+        - switch
+        - map
+
+    exhaustruct:
+      # List of regular expressions to exclude struct packages and their names from checks.
+      # Regular expressions must match complete canonical struct package/name/structname.
+      # Default: []
+      exclude:
+        # std libs
+        - ^net/http.Client$
+        - ^net/http.Cookie$
+        - ^net/http.Request$
+        - ^net/http.Response$
+        - ^net/http.Server$
+        - ^net/http.Transport$
+        - ^net/url.URL$
+        - ^os/exec.Cmd$
+        - ^reflect.StructField$
+        # public libs
+        - ^github.com/Shopify/sarama.Config$
+        - ^github.com/Shopify/sarama.ProducerMessage$
+        - ^github.com/mitchellh/mapstructure.DecoderConfig$
+        - ^github.com/prometheus/client_golang/.+Opts$
+        - ^github.com/spf13/cobra.Command$
+        - ^github.com/spf13/cobra.CompletionOptions$
+        - ^github.com/stretchr/testify/mock.Mock$
+        - ^github.com/testcontainers/testcontainers-go.+Request$
+        - ^github.com/testcontainers/testcontainers-go.FromDockerfile$
+        - ^golang.org/x/tools/go/analysis.Analyzer$
+        - ^google.golang.org/protobuf/.+Options$
+        - ^gopkg.in/yaml.v3.Node$
+
+    funcorder:
+      # Checks if the exported methods of a structure are placed before the non-exported ones.
+      # Default: true
+      struct-method: false
+
+    funlen:
+      # Checks the number of lines in a function.
+      # If lower than 0, disable the check.
+      # Default: 60
+      lines: 100
+      # Checks the number of statements in a function.
+      # If lower than 0, disable the check.
+      # Default: 40
+      statements: 50
+
+    gochecksumtype:
+      # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
+      # Default: true
+      default-signifies-exhaustive: false
+
+    gocognit:
+      # Minimal code complexity to report.
+      # Default: 30 (but we recommend 10-20)
+      min-complexity: 20
+
+    gocritic:
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be found at https://go-critic.com/overview.
+      settings:
+        captLocal:
+          # Whether to restrict checker to params only.
+          # Default: true
+          paramsOnly: false
+        underef:
+          # Whether to skip (*x).method() calls where x is a pointer receiver.
+          # Default: true
+          skipRecvDeref: false
+
+    govet:
+      # Enable all analyzers.
+      # Default: false
+      enable-all: true
+      # Disable analyzers by name.
+      # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
+      # Default: []
+      disable:
+        - fieldalignment # too strict
+      # Settings per analyzer.
+      settings:
+        shadow:
+          # Whether to be strict about shadowing; can be noisy.
+          # Default: false
+          strict: true
+
+    inamedparam:
+      # Skips check for interface methods with only a single parameter.
+      # Default: false
+      skip-single-param: true
+
+    mnd:
+      # List of function patterns to exclude from analysis.
+      # Values always ignored: `time.Date`,
+      # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+      # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+      # Default: []
+      ignored-functions:
+        - args.Error
+        - flag.Arg
+        - flag.Duration.*
+        - flag.Float.*
+        - flag.Int.*
+        - flag.Uint.*
+        - os.Chmod
+        - os.Mkdir.*
+        - os.OpenFile
+        - os.WriteFile
+        - prometheus.ExponentialBuckets.*
+        - prometheus.LinearBuckets
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 0
+
+    nolintlint:
+      # Exclude following linters from requiring an explanation.
+      # Default: []
+      allow-no-explanation: [funlen, gocognit, golines]
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+
+    perfsprint:
+      # Optimizes into strings concatenation.
+      # Default: true
+      strconcat: false
+
+    reassign:
+      # Patterns for global variable names that are checked for reassignment.
+      # See https://github.com/curioswitch/go-reassign#usage
+      # Default: ["EOF", "Err.*"]
+      patterns:
+        - ".*"
+
+    rowserrcheck:
+      # database/sql is always checked.
+      # Default: []
+      packages:
+        - github.com/jmoiron/sqlx
+
+    sloglint:
+      # Enforce not using global loggers.
+      # Values:
+      # - "": disabled
+      # - "all": report all global loggers
+      # - "default": report only the default slog logger
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
+      # Default: ""
+      no-global: all
+      # Enforce using methods that accept a context.
+      # Values:
+      # - "": disabled
+      # - "all": report all contextless calls
+      # - "scope": report only if a context exists in the scope of the outermost function
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
+      # Default: ""
+      context: scope
+
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
+      # Example (to disable some checks): [ "all", "-SA1000", "-SA1001"]
+      # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      checks:
+        - all
+        # Incorrect or missing package comment.
+        # https://staticcheck.dev/docs/checks/#ST1000
+        - -ST1000
+        # Use consistent method receiver names.
+        # https://staticcheck.dev/docs/checks/#ST1016
+        - -ST1016
+        # Omit embedded fields from selector expression.
+        # https://staticcheck.dev/docs/checks/#QF1008
+        - -QF1008
+
+    usetesting:
+      # Enable/disable `os.TempDir()` detections.
+      # Default: false
+      os-temp-dir: true
+
+  exclusions:
+    # Log a warning if an exclusion rule is unused.
+    # Default: false
+    warn-unused: true
+    # Predefined exclusion rules.
+    # Default: []
+    presets:
+      - std-error-handling
+      - common-false-positives
+    # Excluding configuration per-path, per-linter, per-text and per-source.
+    rules:
+      - source: "TODO"
+        linters: [godot]
+      - text: "should have a package comment"
+        linters: [revive]
+      - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
+        linters: [revive]
+      - text: 'package comment should be of the form ".+"'
+        source: "// ?(nolint|TODO)"
+        linters: [revive]
+      - text: 'comment on exported \S+ \S+ should be of the form ".+"'
+        source: "// ?(nolint|TODO)"
+        linters: [revive, staticcheck]
+      - path: '_test\.go'
+        linters:
+          - bodyclose
+          - dupl
+          - errcheck
+          - funlen
+          - goconst
+          - gosec
+          - noctx
+          - wrapcheck

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
-GOLANGCI_LINT_VERSION := v1.63.4
 CONTROLLER_TOOLS_VERSION := v0.16.5
 ENVTEST_VERSION := release-0.19
 ENVTEST_K8S_VERSION := 1.31.0
 
-GOLANGCI_LINT ?= go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 CONTROLLER_GEN ?= go run sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 ENVTEST ?= go run sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
@@ -25,11 +23,12 @@ fmt:
 	go fmt ./...
 
 .PHOHY: lint
-lint:
+lint: golangci-lint
 	$(GOLANGCI_LINT) run --verbose
 
-lint-clean:
-	$(GOLANGCI_LINT) cache clean
+.PHONY: lint-fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
+	$(GOLANGCI_LINT) run --fix
 
 .PHOHY: vet
 vet:
@@ -71,3 +70,35 @@ generate-storage: generate-storage-test-crd ## Generate storage  code in pkg/gen
 .PHONY: generate-mocks
 generate-mocks: ## Generate mocks for testing.
 	go generate ./...
+
+##@ Dependencies
+
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+
+## Tool Versions
+GOLANGCI_LINT_VERSION ?= v2.1.6
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary (ideally with version)
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
+}
+endef

--- a/api/storage/v1alpha1/register.go
+++ b/api/storage/v1alpha1/register.go
@@ -47,7 +47,7 @@ var (
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to the given scheme.
+// AddKnownTypes adds the list of known types to the given scheme.
 func AddKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Image{},
@@ -64,7 +64,10 @@ func AddKnownTypes(scheme *runtime.Scheme) error {
 		&metav1.ListOptions{},
 	)
 
-	err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Image"), imageMetadataFieldSelectorConversion)
+	err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("Image"),
+		imageMetadataFieldSelectorConversion,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to add field selector conversion function to Image: %w", err)
 	}
@@ -74,7 +77,10 @@ func AddKnownTypes(scheme *runtime.Scheme) error {
 		return fmt.Errorf("unable to add field selector conversion function to SBOM: %w", err)
 	}
 
-	err = scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("VulnerabilityReport"), imageMetadataFieldSelectorConversion)
+	err = scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("VulnerabilityReport"),
+		imageMetadataFieldSelectorConversion,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to add field selector conversion function to VulnerabilityReport: %w", err)
 	}
@@ -100,6 +106,12 @@ func imageMetadataFieldSelectorConversion(label, value string) (string, string, 
 	case "spec.imageMetadata.digest":
 		return label, value, nil
 	default:
-		return "", "", fmt.Errorf("%q is not a known field selector: only %q, %q, %q", label, "metadata.name", "metadata.namespace", "spec.imageMetadata.*")
+		return "", "", fmt.Errorf(
+			"%q is not a known field selector: only %q, %q, %q",
+			label,
+			"metadata.name",
+			"metadata.namespace",
+			"spec.imageMetadata.*",
+		)
 	}
 }

--- a/api/v1alpha1/registry_types.go
+++ b/api/v1alpha1/registry_types.go
@@ -80,8 +80,8 @@ type Registry struct {
 
 // RegistryList contains a list of Registry
 type RegistryList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `           json:",inline"`
+	metav1.ListMeta `           json:"metadata,omitempty"`
 	Items           []Registry `json:"items"`
 }
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -88,7 +88,12 @@ func main() {
 	cfg := parseFlags()
 	logger, err := setupLogger(cfg)
 	if err != nil {
-		slog.Error("error initializing the logger", "error", err) //nolint:sloglint // Use the global logger since the logger is not yet initialized
+		//nolint:sloglint // Use the global logger since the logger is not yet initialized
+		slog.Error(
+			"error initializing the logger",
+			"error",
+			err,
+		)
 		os.Exit(1)
 	}
 
@@ -218,17 +223,17 @@ func main() {
 
 	// +kubebuilder:scaffold:builder
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err = mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err = mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/cmd/storage/server/start.go
+++ b/cmd/storage/server/start.go
@@ -147,7 +147,13 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 
 	// Set the emulation version mapping from the "Wardle" component to the kube component.
 	// This ensures that the emulation version of the latter is determined by the emulation version of the former.
-	utilruntime.Must(featuregate.DefaultComponentGlobalsRegistry.SetEmulationVersionMapping(apiserver.WardleComponentName, featuregate.DefaultKubeComponent, WardleVersionToKubeVersion))
+	utilruntime.Must(
+		featuregate.DefaultComponentGlobalsRegistry.SetEmulationVersionMapping(
+			apiserver.WardleComponentName,
+			featuregate.DefaultKubeComponent,
+			WardleVersionToKubeVersion,
+		),
+	)
 
 	featuregate.DefaultComponentGlobalsRegistry.AddFlags(flags)
 
@@ -155,7 +161,7 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 }
 
 // Validate validates WardleServerOptions
-func (o WardleServerOptions) Validate(_ []string) error {
+func (o *WardleServerOptions) Validate(_ []string) error {
 	errors := []error{}
 	errors = append(errors, o.RecommendedOptions.Validate()...)
 	errors = append(errors, featuregate.DefaultComponentGlobalsRegistry.Validate()...)
@@ -176,16 +182,26 @@ func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 
 	serverConfig := genericapiserver.NewRecommendedConfig(apiserver.Codecs)
 
-	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(sampleopenapi.GetOpenAPIDefinitions, openapi.NewDefinitionNamer(apiserver.Scheme))
+	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(
+		sampleopenapi.GetOpenAPIDefinitions,
+		openapi.NewDefinitionNamer(apiserver.Scheme),
+	)
 	serverConfig.OpenAPIConfig.Info.Title = "Wardle"
 	serverConfig.OpenAPIConfig.Info.Version = "0.1"
 
-	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(sampleopenapi.GetOpenAPIDefinitions, openapi.NewDefinitionNamer(apiserver.Scheme))
+	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(
+		sampleopenapi.GetOpenAPIDefinitions,
+		openapi.NewDefinitionNamer(apiserver.Scheme),
+	)
 	serverConfig.OpenAPIV3Config.Info.Title = "Wardle"
 	serverConfig.OpenAPIV3Config.Info.Version = "0.1"
 
-	serverConfig.FeatureGate = featuregate.DefaultComponentGlobalsRegistry.FeatureGateFor(featuregate.DefaultKubeComponent)
-	serverConfig.EffectiveVersion = featuregate.DefaultComponentGlobalsRegistry.EffectiveVersionFor(apiserver.WardleComponentName)
+	serverConfig.FeatureGate = featuregate.DefaultComponentGlobalsRegistry.FeatureGateFor(
+		featuregate.DefaultKubeComponent,
+	)
+	serverConfig.EffectiveVersion = featuregate.DefaultComponentGlobalsRegistry.EffectiveVersionFor(
+		apiserver.WardleComponentName,
+	)
 
 	// As we don't have a real etcd, we need to set a dummy storage factory
 	serverConfig.RESTOptionsGetter = &genericoptions.StorageFactoryRestOptionsFactory{
@@ -204,7 +220,7 @@ func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 }
 
 // RunWardleServer starts a new WardleServer given WardleServerOptions
-func (o WardleServerOptions) RunWardleServer(ctx context.Context) error {
+func (o *WardleServerOptions) RunWardleServer(ctx context.Context) error {
 	config, err := o.Config()
 	if err != nil {
 		return err
@@ -215,7 +231,7 @@ func (o WardleServerOptions) RunWardleServer(ctx context.Context) error {
 		return fmt.Errorf("error creating server: %w", err)
 	}
 
-	if err := server.GenericAPIServer.PrepareRun().RunWithContext(ctx); err != nil {
+	if err = server.GenericAPIServer.PrepareRun().RunWithContext(ctx); err != nil {
 		return fmt.Errorf("error while running server: %w", err)
 	}
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -33,7 +33,12 @@ func main() {
 
 	slogLevel, err := cmdutil.ParseLogLevel(logLevel)
 	if err != nil {
-		slog.Error("error initializing the logger", "error", err) //nolint:sloglint // Use the global logger since the logger is not yet initialized
+		//nolint:sloglint // Use the global logger since the logger is not yet initialized
+		slog.Error(
+			"error initializing the logger",
+			"error",
+			err,
+		)
 		os.Exit(1)
 	}
 	opts := slog.HandlerOptions{
@@ -50,11 +55,11 @@ func main() {
 
 	config := ctrl.GetConfigOrDie()
 	scheme := scheme.Scheme
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
+	if err = v1alpha1.AddToScheme(scheme); err != nil {
 		logger.Error("Error adding v1alpha1 to scheme", "error", err)
 		os.Exit(1)
 	}
-	if err := storagev1alpha1.AddToScheme(scheme); err != nil {
+	if err = storagev1alpha1.AddToScheme(scheme); err != nil {
 		logger.Error("Error adding storagev1alpha1 to scheme", "error", err)
 		os.Exit(1)
 	}

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -118,7 +118,12 @@ func (c completedConfig) New(db *sqlx.DB, logger *slog.Logger) (*WardleServer, e
 	if err != nil {
 		return nil, fmt.Errorf("error creating SBOM store: %w", err)
 	}
-	vulnerabilityReportStore, err := storage.NewVulnerabilityReport(Scheme, c.GenericConfig.RESTOptionsGetter, db, logger)
+	vulnerabilityReportStore, err := storage.NewVulnerabilityReport(
+		Scheme,
+		c.GenericConfig.RESTOptionsGetter,
+		db,
+		logger,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VulnerabilityReport store: %w", err)
 	}
@@ -129,7 +134,7 @@ func (c completedConfig) New(db *sqlx.DB, logger *slog.Logger) (*WardleServer, e
 	v1alpha1storage["vulnerabilityreports"] = vulnerabilityReportStore
 	apiGroupInfo.VersionedResourcesStorageMap["v1alpha1"] = v1alpha1storage
 
-	if err := s.GenericAPIServer.InstallAPIGroup(&apiGroupInfo); err != nil {
+	if err = s.GenericAPIServer.InstallAPIGroup(&apiGroupInfo); err != nil {
 		return nil, fmt.Errorf("error installing API group: %w", err)
 	}
 

--- a/internal/controller/image_controller.go
+++ b/internal/controller/image_controller.go
@@ -65,7 +65,7 @@ func (r *ImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				ImageNamespace: image.Namespace,
 			}
 
-			if err := r.Publisher.Publish(&msg); err != nil {
+			if err = r.Publisher.Publish(&msg); err != nil {
 				return ctrl.Result{}, fmt.Errorf("unable to publish CreateSBOM message: %w", err)
 			}
 		} else {

--- a/internal/controller/sbom_controller.go
+++ b/internal/controller/sbom_controller.go
@@ -88,10 +88,16 @@ func (r *SBOMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	// Check if all images have SBOMs
 	if len(sbomList.Items) == len(imageList.Items) {
-		log.Info("Registry discovery is completed.", "name", sbom.GetImageMetadata().Registry, "namespace", req.Namespace)
+		log.Info(
+			"Registry discovery is completed.",
+			"name",
+			sbom.GetImageMetadata().Registry,
+			"namespace",
+			req.Namespace,
+		)
 
 		var registry v1alpha1.Registry
-		err := r.Get(ctx, client.ObjectKey{
+		err = r.Get(ctx, client.ObjectKey{
 			Name:      sbom.GetImageMetadata().Registry,
 			Namespace: req.Namespace,
 		}, &registry)
@@ -101,7 +107,8 @@ func (r *SBOMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 		_, found := registry.Annotations[v1alpha1.RegistryLastDiscoveredAtAnnotation]
 		if found {
-			log.V(1).Info("Registry already has a last discovered timestamp", "name", registry.Name, "namespace", registry.Namespace)
+			log.V(1).
+				Info("Registry already has a last discovered timestamp", "name", registry.Name, "namespace", registry.Namespace)
 
 			return ctrl.Result{}, nil
 		}
@@ -110,10 +117,11 @@ func (r *SBOMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			registry.Annotations = make(map[string]string)
 		}
 
-		log.V(1).Info("Updating Registry last discovered timestamp", "name", registry.Name, "namespace", registry.Namespace)
+		log.V(1).
+			Info("Updating Registry last discovered timestamp", "name", registry.Name, "namespace", registry.Namespace)
 
 		registry.Annotations[v1alpha1.RegistryLastDiscoveredAtAnnotation] = time.Now().Format(time.RFC3339)
-		if err := r.Update(ctx, &registry); err != nil {
+		if err = r.Update(ctx, &registry); err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to update Registry LastScannedAt: %w", err)
 		}
 	}

--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -37,7 +37,12 @@ type CreateCatalogHandler struct {
 	logger                *slog.Logger
 }
 
-func NewCreateCatalogHandler(registryClientFactory registryclient.ClientFactory, k8sClient client.Client, scheme *runtime.Scheme, logger *slog.Logger) *CreateCatalogHandler {
+func NewCreateCatalogHandler(
+	registryClientFactory registryclient.ClientFactory,
+	k8sClient client.Client,
+	scheme *runtime.Scheme,
+	logger *slog.Logger,
+) *CreateCatalogHandler {
 	return &CreateCatalogHandler{
 		registryClientFactory: registryClientFactory,
 		k8sClient:             k8sClient,
@@ -46,6 +51,7 @@ func NewCreateCatalogHandler(registryClientFactory registryclient.ClientFactory,
 	}
 }
 
+//nolint:gocognit // We are a bit more tolerant for the handler.
 func (h *CreateCatalogHandler) Handle(message messaging.Message) error {
 	createCatalogMessage, ok := message.(*messaging.CreateCatalog)
 	if !ok {
@@ -65,7 +71,12 @@ func (h *CreateCatalogHandler) Handle(message messaging.Message) error {
 		Namespace: createCatalogMessage.RegistryNamespace,
 	}, registry)
 	if err != nil {
-		return fmt.Errorf("cannot get registry %s/%s: %w", createCatalogMessage.RegistryNamespace, createCatalogMessage.RegistryName, err)
+		return fmt.Errorf(
+			"cannot get registry %s/%s: %w",
+			createCatalogMessage.RegistryNamespace,
+			createCatalogMessage.RegistryName,
+			err,
+		)
 	}
 
 	h.logger.Debug("Registry found", "registry", registry)
@@ -83,7 +94,8 @@ func (h *CreateCatalogHandler) Handle(message messaging.Message) error {
 
 	discoveredImageNames := sets.Set[string]{}
 	for _, repository := range repositories {
-		repoImages, err := h.discoverImages(ctx, registryClient, repository)
+		var repoImages []string
+		repoImages, err = h.discoverImages(ctx, registryClient, repository)
 		if err != nil {
 			return fmt.Errorf("cannot discover images in registry %s: %w", registry.Name, err)
 		}
@@ -91,7 +103,7 @@ func (h *CreateCatalogHandler) Handle(message messaging.Message) error {
 	}
 
 	existingImageList := &storagev1alpha1.ImageList{}
-	if err := h.k8sClient.List(ctx, existingImageList, client.InNamespace(registry.Namespace), client.MatchingLabels{"registry": registry.Name}); err != nil {
+	if err = h.k8sClient.List(ctx, existingImageList, client.InNamespace(registry.Namespace), client.MatchingLabels{"registry": registry.Name}); err != nil {
 		return fmt.Errorf("cannot list existing images in registry %s: %w", registry.Name, err)
 	}
 	existingImageNames := sets.Set[string]{}
@@ -100,12 +112,14 @@ func (h *CreateCatalogHandler) Handle(message messaging.Message) error {
 	}
 
 	for newImageName := range discoveredImageNames {
-		ref, err := name.ParseReference(newImageName)
+		var ref name.Reference
+		ref, err = name.ParseReference(newImageName)
 		if err != nil {
 			return fmt.Errorf("cannot parse reference %s: %w", newImageName, err)
 		}
 
-		images, err := h.refToImages(registryClient, ref, registry)
+		var images []storagev1alpha1.Image
+		images, err = h.refToImages(registryClient, ref, registry)
 		if err != nil {
 			h.logger.Info("cannot get images", "reference", ref.String(), "error", err)
 			// Avoid blocking other images to be cataloged
@@ -117,13 +131,13 @@ func (h *CreateCatalogHandler) Handle(message messaging.Message) error {
 				continue
 			}
 
-			if err := h.k8sClient.Create(ctx, &image); err != nil {
+			if err = h.k8sClient.Create(ctx, &image); err != nil {
 				return fmt.Errorf("cannot create image %s: %w", image.Name, err)
 			}
 		}
 	}
 
-	if err := h.deleteObsoleteImages(ctx, existingImageNames, discoveredImageNames, registry.Namespace); err != nil {
+	if err = h.deleteObsoleteImages(ctx, existingImageNames, discoveredImageNames, registry.Namespace); err != nil {
 		return fmt.Errorf("cannot delete obsolete images in registry %s: %w", registry.Name, err)
 	}
 
@@ -136,7 +150,11 @@ func (h *CreateCatalogHandler) NewMessage() messaging.Message {
 
 // discoverRepositories discovers all the repositories in a registry.
 // Returns the list of fully qualified repository names (e.g. registryclientexample.com/repo)
-func (h *CreateCatalogHandler) discoverRepositories(ctx context.Context, registryClient registryclient.Client, registry *v1alpha1.Registry) ([]string, error) {
+func (h *CreateCatalogHandler) discoverRepositories(
+	ctx context.Context,
+	registryClient registryclient.Client,
+	registry *v1alpha1.Registry,
+) ([]string, error) {
 	reg, err := name.NewRegistry(registry.Spec.URI)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse registry %s %s: %w", registry.Name, registry.Namespace, err)
@@ -145,7 +163,8 @@ func (h *CreateCatalogHandler) discoverRepositories(ctx context.Context, registr
 	// If the registry doesn't have any repositories defined, it means we need to catalog all of them.
 	// In this case, we need to discover all the repositories in the registry.
 	if len(registry.Spec.Repositories) == 0 {
-		allRepositories, err := registryClient.Catalog(ctx, reg)
+		var allRepositories []string
+		allRepositories, err = registryClient.Catalog(ctx, reg)
 		if err != nil {
 			return []string{}, fmt.Errorf("cannot discover repositories: %w", err)
 		}
@@ -163,7 +182,11 @@ func (h *CreateCatalogHandler) discoverRepositories(ctx context.Context, registr
 
 // discoverImages discovers all the images defined inside of a repository.
 // Returns the list of fully qualified image names (e.g. registryclientexample.com/repo:tag)
-func (h *CreateCatalogHandler) discoverImages(ctx context.Context, registryClient registryclient.Client, repository string) ([]string, error) {
+func (h *CreateCatalogHandler) discoverImages(
+	ctx context.Context,
+	registryClient registryclient.Client,
+	repository string,
+) ([]string, error) {
 	repo, err := name.NewRepository(repository)
 	if err != nil {
 		return []string{}, fmt.Errorf("cannot parse repository name %q: %w", repository, err)
@@ -177,7 +200,11 @@ func (h *CreateCatalogHandler) discoverImages(ctx context.Context, registryClien
 	return contents, nil
 }
 
-func (h *CreateCatalogHandler) refToImages(registryClient registryclient.Client, ref name.Reference, registry *v1alpha1.Registry) ([]storagev1alpha1.Image, error) {
+func (h *CreateCatalogHandler) refToImages(
+	registryClient registryclient.Client,
+	ref name.Reference,
+	registry *v1alpha1.Registry,
+) ([]storagev1alpha1.Image, error) {
 	platforms, err := h.refToPlatforms(registryClient, ref)
 	if err != nil {
 		return []storagev1alpha1.Image{}, fmt.Errorf("cannot get platforms for %s: %w", ref, err)
@@ -190,7 +217,8 @@ func (h *CreateCatalogHandler) refToImages(registryClient registryclient.Client,
 	images := []storagev1alpha1.Image{}
 
 	for _, platform := range platforms {
-		imageDetails, err := registryClient.GetImageDetails(ref, platform)
+		var imageDetails registryclient.ImageDetails
+		imageDetails, err = registryClient.GetImageDetails(ref, platform)
 		if err != nil {
 			platformStr := "default"
 			if platform != nil {
@@ -201,14 +229,15 @@ func (h *CreateCatalogHandler) refToImages(registryClient registryclient.Client,
 			continue
 		}
 
-		image, err := imageDetailsToImage(ref, imageDetails, registry)
+		var image storagev1alpha1.Image
+		image, err = imageDetailsToImage(ref, imageDetails, registry)
 		if err != nil {
 			h.logger.Info("cannot convert image details to image", "reference", ref.Name(), "error", err)
 			// Avoid blocking other images to be cataloged
 			continue
 		}
 
-		if err := controllerutil.SetControllerReference(registry, &image, h.scheme); err != nil {
+		if err = controllerutil.SetControllerReference(registry, &image, h.scheme); err != nil {
 			h.logger.Info("cannot set owner reference", "reference", ref.Name(), "error", err)
 			// Avoid blocking other images to be cataloged
 			continue
@@ -222,7 +251,10 @@ func (h *CreateCatalogHandler) refToImages(registryClient registryclient.Client,
 
 // refToPlatforms returns the list of platforms for the given image reference.
 // If the image is not multi-architecture, it returns an empty list.
-func (h *CreateCatalogHandler) refToPlatforms(registryClient registryclient.Client, ref name.Reference) ([]*cranev1.Platform, error) {
+func (h *CreateCatalogHandler) refToPlatforms(
+	registryClient registryclient.Client,
+	ref name.Reference,
+) ([]*cranev1.Platform, error) {
 	imgIndex, err := registryClient.GetImageIndex(ref)
 	if err != nil {
 		h.logger.Debug(
@@ -265,7 +297,7 @@ func (h *CreateCatalogHandler) transportFromRegistry(registry *v1alpha1.Registry
 			rootCAs = x509.NewCertPool()
 		}
 
-		ok := rootCAs.AppendCertsFromPEM([]byte(registry.Spec.CABundle))
+		ok = rootCAs.AppendCertsFromPEM([]byte(registry.Spec.CABundle))
 		if ok {
 			transport.TLSClientConfig.RootCAs = rootCAs
 		} else {
@@ -279,7 +311,12 @@ func (h *CreateCatalogHandler) transportFromRegistry(registry *v1alpha1.Registry
 }
 
 // deleteObsoleteImages deletes images that are not present in the discovered registry anymore.
-func (h *CreateCatalogHandler) deleteObsoleteImages(ctx context.Context, existingImageNames sets.Set[string], discoveredImageNames sets.Set[string], namespace string) error {
+func (h *CreateCatalogHandler) deleteObsoleteImages(
+	ctx context.Context,
+	existingImageNames sets.Set[string],
+	discoveredImageNames sets.Set[string],
+	namespace string,
+) error {
 	for existingImageName := range existingImageNames {
 		if discoveredImageNames.Has(existingImageName) {
 			continue
@@ -300,7 +337,11 @@ func (h *CreateCatalogHandler) deleteObsoleteImages(ctx context.Context, existin
 	return nil
 }
 
-func imageDetailsToImage(ref name.Reference, details registryclient.ImageDetails, registry *v1alpha1.Registry) (storagev1alpha1.Image, error) {
+func imageDetailsToImage(
+	ref name.Reference,
+	details registryclient.ImageDetails,
+	registry *v1alpha1.Registry,
+) (storagev1alpha1.Image, error) {
 	imageLayers := []storagev1alpha1.ImageLayer{}
 
 	// There can be more history entries than layers, as some history entries are empty layers
@@ -312,7 +353,11 @@ func imageDetailsToImage(ref name.Reference, details registryclient.ImageDetails
 		}
 
 		if len(details.Layers) < layerCounter {
-			return storagev1alpha1.Image{}, fmt.Errorf("layer %d not found - got only %d layers", layerCounter, len(details.Layers))
+			return storagev1alpha1.Image{}, fmt.Errorf(
+				"layer %d not found - got only %d layers",
+				layerCounter,
+				len(details.Layers),
+			)
 		}
 		layer := details.Layers[layerCounter]
 		digest, err := layer.Digest()
@@ -357,6 +402,6 @@ func imageDetailsToImage(ref name.Reference, details registryclient.ImageDetails
 // computeImageUID returns the sha256 of “<image-name>@sha256:<digest>`
 func computeImageUID(ref name.Reference, digest string) string {
 	sha := sha256.New()
-	sha.Write([]byte(fmt.Sprintf("%s:%s@%s", ref.Context().Name(), ref.Identifier(), digest)))
+	fmt.Fprintf(sha, "%s:%s@%s", ref.Context().Name(), ref.Identifier(), digest)
 	return hex.EncodeToString(sha.Sum(nil))
 }

--- a/internal/handlers/generate_sbom.go
+++ b/internal/handlers/generate_sbom.go
@@ -27,7 +27,12 @@ type GenerateSBOMHandler struct {
 	logger    *slog.Logger
 }
 
-func NewGenerateSBOMHandler(k8sClient client.Client, scheme *runtime.Scheme, workDir string, logger *slog.Logger) *GenerateSBOMHandler {
+func NewGenerateSBOMHandler(
+	k8sClient client.Client,
+	scheme *runtime.Scheme,
+	workDir string,
+	logger *slog.Logger,
+) *GenerateSBOMHandler {
 	return &GenerateSBOMHandler{
 		k8sClient: k8sClient,
 		scheme:    scheme,
@@ -55,7 +60,12 @@ func (h *GenerateSBOMHandler) Handle(message messaging.Message) error {
 		Namespace: generateSBOMMessage.ImageNamespace,
 	}, image)
 	if err != nil {
-		return fmt.Errorf("cannot get image %s/%s: %w", generateSBOMMessage.ImageNamespace, generateSBOMMessage.ImageName, err)
+		return fmt.Errorf(
+			"cannot get image %s/%s: %w",
+			generateSBOMMessage.ImageNamespace,
+			generateSBOMMessage.ImageName,
+			err,
+		)
 	}
 
 	h.logger.Debug("Image found",
@@ -67,11 +77,11 @@ func (h *GenerateSBOMHandler) Handle(message messaging.Message) error {
 		return fmt.Errorf("failed to create temporary SBOM file: %w", err)
 	}
 	defer func() {
-		if err := sbomFile.Close(); err != nil {
+		if err = sbomFile.Close(); err != nil {
 			h.logger.Error("failed to close temporary SBOM file", "error", err)
 		}
 
-		if err := os.Remove(sbomFile.Name()); err != nil {
+		if err = os.Remove(sbomFile.Name()); err != nil {
 			h.logger.Error("failed to remove temporary SBOM file", "error", err)
 		}
 	}()
@@ -84,10 +94,15 @@ func (h *GenerateSBOMHandler) Handle(message messaging.Message) error {
 		"--db-repository", "public.ecr.aws/aquasecurity/trivy-db",
 		"--java-db-repository", "public.ecr.aws/aquasecurity/trivy-java-db",
 		"--output", sbomFile.Name(),
-		fmt.Sprintf("%s/%s:%s", image.GetImageMetadata().RegistryURI, image.GetImageMetadata().Repository, image.GetImageMetadata().Tag),
+		fmt.Sprintf(
+			"%s/%s:%s",
+			image.GetImageMetadata().RegistryURI,
+			image.GetImageMetadata().Repository,
+			image.GetImageMetadata().Tag,
+		),
 	})
 
-	if err := app.ExecuteContext(ctx); err != nil {
+	if err = app.ExecuteContext(ctx); err != nil {
 		return fmt.Errorf("failed to execute trivy: %w", err)
 	}
 
@@ -111,11 +126,11 @@ func (h *GenerateSBOMHandler) Handle(message messaging.Message) error {
 			SPDX:          runtime.RawExtension{Raw: spdxBytes},
 		},
 	}
-	if err := controllerutil.SetControllerReference(image, sbom, h.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(image, sbom, h.scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference: %w", err)
 	}
 
-	if err := h.k8sClient.Create(ctx, sbom); err != nil {
+	if err = h.k8sClient.Create(ctx, sbom); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create SBOM: %w", err)
 		}

--- a/internal/handlers/generate_sbom_test.go
+++ b/internal/handlers/generate_sbom_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"log/slog"
 	"os"
@@ -66,7 +65,7 @@ func TestGenerateSBOMHandler_Handle(t *testing.T) {
 	require.NoError(t, err)
 
 	sbom := &storagev1alpha1.SBOM{}
-	err = k8sClient.Get(context.Background(), types.NamespacedName{
+	err = k8sClient.Get(t.Context(), types.NamespacedName{
 		Name:      image.Name,
 		Namespace: image.Namespace,
 	}, sbom)

--- a/internal/handlers/registry/client.go
+++ b/internal/handlers/registry/client.go
@@ -81,7 +81,8 @@ func (c *client) Catalog(ctx context.Context, registry name.Registry) ([]string,
 	repositories := []string{}
 
 	for catalogger.HasNext() {
-		repos, err := catalogger.Next(ctx)
+		var repos *remote.Catalogs
+		repos, err = catalogger.Next(ctx)
 		if err != nil {
 			return []string{}, fmt.Errorf("cannot iterate over repository %s contents: %w", registry.Name(), err)
 		}
@@ -116,7 +117,8 @@ func (c *client) ListRepositoryContents(ctx context.Context, repo name.Repositor
 
 	images := []string{}
 	for lister.HasNext() {
-		tags, err := lister.Next(ctx)
+		var tags *remote.Tags
+		tags, err = lister.Next(ctx)
 		if err != nil {
 			return []string{}, fmt.Errorf("cannot iterate over repository contents: %w", err)
 		}

--- a/internal/handlers/scan_sbom.go
+++ b/internal/handlers/scan_sbom.go
@@ -27,7 +27,12 @@ type ScanSBOMHandler struct {
 	logger    *slog.Logger
 }
 
-func NewScanSBOMHandler(k8sClient client.Client, scheme *runtime.Scheme, workDir string, logger *slog.Logger) *ScanSBOMHandler {
+func NewScanSBOMHandler(
+	k8sClient client.Client,
+	scheme *runtime.Scheme,
+	workDir string,
+	logger *slog.Logger,
+) *ScanSBOMHandler {
 	return &ScanSBOMHandler{
 		k8sClient: k8sClient,
 		scheme:    scheme,
@@ -36,7 +41,6 @@ func NewScanSBOMHandler(k8sClient client.Client, scheme *runtime.Scheme, workDir
 	}
 }
 
-//nolint:funlen //right now this is 2 lines too long because of error handling, if it grows more we should refactor
 func (h *ScanSBOMHandler) Handle(message messaging.Message) error {
 	scanSBOMMessage, ok := message.(*messaging.ScanSBOM)
 	if !ok {
@@ -64,11 +68,11 @@ func (h *ScanSBOMHandler) Handle(message messaging.Message) error {
 		return fmt.Errorf("failed to create temporary SBOM file: %w", err)
 	}
 	defer func() {
-		if err := sbomFile.Close(); err != nil {
+		if err = sbomFile.Close(); err != nil {
 			h.logger.Error("failed to close temporary SBOM file", "error", err)
 		}
 
-		if err := os.Remove(sbomFile.Name()); err != nil {
+		if err = os.Remove(sbomFile.Name()); err != nil {
 			h.logger.Error("failed to remove temporary SBOM file", "error", err)
 		}
 	}()
@@ -82,11 +86,11 @@ func (h *ScanSBOMHandler) Handle(message messaging.Message) error {
 		return fmt.Errorf("failed to create temporary report file: %w", err)
 	}
 	defer func() {
-		if err := reportFile.Close(); err != nil {
+		if err = reportFile.Close(); err != nil {
 			h.logger.Error("failed to close temporary report file", "error", err)
 		}
 
-		if err := os.Remove(reportFile.Name()); err != nil {
+		if err = os.Remove(reportFile.Name()); err != nil {
 			h.logger.Error("failed to remove temporary repoort file", "error", err)
 		}
 	}()
@@ -104,7 +108,7 @@ func (h *ScanSBOMHandler) Handle(message messaging.Message) error {
 		sbomFile.Name(),
 	})
 
-	if err := app.ExecuteContext(ctx); err != nil {
+	if err = app.ExecuteContext(ctx); err != nil {
 		return fmt.Errorf("failed to execute trivy: %w", err)
 	}
 
@@ -124,7 +128,7 @@ func (h *ScanSBOMHandler) Handle(message messaging.Message) error {
 			Namespace: sbom.Namespace,
 		},
 	}
-	if err := controllerutil.SetControllerReference(sbom, vulnerabilityReport, h.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(sbom, vulnerabilityReport, h.scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference: %w", err)
 	}
 

--- a/internal/handlers/scan_sbom_test.go
+++ b/internal/handlers/scan_sbom_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"log/slog"
 	"os"
@@ -62,7 +61,7 @@ func TestScanSBOMHandler_Handle(t *testing.T) {
 	require.NoError(t, err)
 
 	vulnerabilityReport := &storagev1alpha1.VulnerabilityReport{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{
+	err = k8sClient.Get(t.Context(), client.ObjectKey{
 		Name:      sbom.Name,
 		Namespace: sbom.Namespace,
 	}, vulnerabilityReport)

--- a/internal/messaging/publisher.go
+++ b/internal/messaging/publisher.go
@@ -39,7 +39,7 @@ func (p *publisher) Publish(message Message) error {
 		Header:  header,
 	}
 
-	if _, err := p.js.PublishMsg(msg); err != nil {
+	if _, err = p.js.PublishMsg(msg); err != nil {
 		return fmt.Errorf("failed to publish message: %w", err)
 	}
 

--- a/internal/messaging/publisher_test.go
+++ b/internal/messaging/publisher_test.go
@@ -33,7 +33,7 @@ func TestPublisher_Publish(t *testing.T) {
 	sub, err := js.SubscribeSync(sbombasticSubject)
 	require.NoError(t, err)
 	defer func() {
-		err := sub.Unsubscribe()
+		err = sub.Unsubscribe()
 		require.NoError(t, err)
 	}()
 

--- a/internal/messaging/subscriber.go
+++ b/internal/messaging/subscriber.go
@@ -27,6 +27,7 @@ func NewSubscriber(sub *nats.Subscription, handlers HandlerRegistry, logger *slo
 	}
 }
 
+//nolint:gocognit // We are a bit more tolerant for the runner.
 func (s *Subscriber) Run(ctx context.Context) error {
 	for {
 		select {
@@ -46,7 +47,7 @@ func (s *Subscriber) Run(ctx context.Context) error {
 
 			for _, msg := range msgs {
 				s.logger.DebugContext(ctx, "Processing message", "message", msg)
-				if err := s.processMessage(msg); err != nil {
+				if err = s.processMessage(msg); err != nil {
 					s.logger.ErrorContext(ctx, "Failed to process message",
 						"subject", msg.Subject,
 						"header", msg.Header,
@@ -55,7 +56,7 @@ func (s *Subscriber) Run(ctx context.Context) error {
 					)
 				}
 
-				if err := msg.Ack(); err != nil {
+				if err = msg.Ack(); err != nil {
 					return fmt.Errorf("failed to ack message: %w", err)
 				}
 			}

--- a/internal/messaging/subscriber_test.go
+++ b/internal/messaging/subscriber_test.go
@@ -55,7 +55,7 @@ func TestSubscriber_Run(t *testing.T) {
 	}
 	subscriber := NewSubscriber(sub, handlers, slog.Default())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	data, err := json.Marshal(message)

--- a/internal/storage/image_store.go
+++ b/internal/storage/image_store.go
@@ -24,7 +24,12 @@ CREATE TABLE IF NOT EXISTS images (
 `
 
 // NewImageStore returns a store registry that will work against API services.
-func NewImageStore(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB, logger *slog.Logger) (*registry.Store, error) {
+func NewImageStore(
+	scheme *runtime.Scheme,
+	optsGetter generic.RESTOptionsGetter,
+	db *sqlx.DB,
+	logger *slog.Logger,
+) (*registry.Store, error) {
 	strategy := newImageStrategy(scheme)
 
 	newFunc := func() runtime.Object { return &v1alpha1.Image{} }

--- a/internal/storage/sbom_store.go
+++ b/internal/storage/sbom_store.go
@@ -24,7 +24,12 @@ CREATE TABLE IF NOT EXISTS sboms (
 `
 
 // NewSBOMStore returns a store registry that will work against API services.
-func NewSBOMStore(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB, logger *slog.Logger) (*registry.Store, error) {
+func NewSBOMStore(
+	scheme *runtime.Scheme,
+	optsGetter generic.RESTOptionsGetter,
+	db *sqlx.DB,
+	logger *slog.Logger,
+) (*registry.Store, error) {
 	strategy := newSBOMStrategy(scheme)
 
 	newFunc := func() runtime.Object { return &v1alpha1.SBOM{} }

--- a/internal/storage/vulnerabilityreport_store.go
+++ b/internal/storage/vulnerabilityreport_store.go
@@ -24,7 +24,12 @@ CREATE TABLE IF NOT EXISTS vulnerabilityreports (
 `
 
 // NewVulnerabilityReport returns a store registry that will work against API services.
-func NewVulnerabilityReport(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, db *sqlx.DB, logger *slog.Logger) (*registry.Store, error) {
+func NewVulnerabilityReport(
+	scheme *runtime.Scheme,
+	optsGetter generic.RESTOptionsGetter,
+	db *sqlx.DB,
+	logger *slog.Logger,
+) (*registry.Store, error) {
 	strategy := newVulnerabilityReportStrategy(scheme)
 
 	newFunc := func() runtime.Object { return &v1alpha1.VulnerabilityReport{} }


### PR DESCRIPTION
Update to v2 of golangci:

- Change how the linter is installed and started by Makefile
- Update GitHub Action
- Update to latest version of golangci-lint golden configuration
- Address linter warnings

Supersedes https://github.com/rancher-sandbox/sbombastic/pull/147
