### PR TITLE
fix(chart): temporarily disable logLevel storage value

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,7 +16,7 @@ storage:
     tag: v0.1.0-alpha1
     pullPolicy: IfNotPresent
   replicas: 1
-  logLevel: "debug"
+  # logLevel: "debug" //TODO: uncomment this, when the log parser in storage is implemented
 
 worker:
   image:


### PR DESCRIPTION
## Description

Temporarily disable the logLevel storage value, as flag parsing and logging in this component still need to be fixed, and it was preventing the storage from starting.