### PR TITLE
fix: add restOptions to ensure the garbage collection is enabled

### DIFF
--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -110,17 +110,18 @@ func (c completedConfig) New(db *sqlx.DB, logger *slog.Logger) (*WardleServer, e
 
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(v1alpha1.GroupName, Scheme, metav1.ParameterCodec, Codecs)
 
-	imageStore, err := storage.NewImageStore(Scheme, c.GenericConfig.RESTOptionsGetter, db, logger)
+	restOptionsGetter := GetRESTOptionsGetter()
+	imageStore, err := storage.NewImageStore(Scheme, restOptionsGetter, db, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Image store: %w", err)
 	}
-	sbomStore, err := storage.NewSBOMStore(Scheme, c.GenericConfig.RESTOptionsGetter, db, logger)
+	sbomStore, err := storage.NewSBOMStore(Scheme, restOptionsGetter, db, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating SBOM store: %w", err)
 	}
 	vulnerabilityReportStore, err := storage.NewVulnerabilityReport(
 		Scheme,
-		c.GenericConfig.RESTOptionsGetter,
+		restOptionsGetter,
 		db,
 		logger,
 	)

--- a/internal/apiserver/options.go
+++ b/internal/apiserver/options.go
@@ -1,0 +1,29 @@
+package apiserver
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/generic"
+)
+
+type RestOptionsGetter struct {
+}
+
+// GetRESTOptions implements the generic.RESTOptionsGetter interface to ensure the GarbageCollection is enabled.
+// ResourcePrefix is set to "/<group>/<resource>", compatible with the storage Key format: /storage.sbombastic.rancher.io/<resource>/<namespace>/<name>.
+func (o *RestOptionsGetter) GetRESTOptions(
+	resource schema.GroupResource,
+	_ runtime.Object,
+) (generic.RESTOptions, error) {
+	return generic.RESTOptions{
+		EnableGarbageCollection: true,
+		DeleteCollectionWorkers: 1,
+		ResourcePrefix:          fmt.Sprintf("/%s/%s", resource.Group, resource.Resource),
+	}, nil
+}
+
+func GetRESTOptionsGetter() *RestOptionsGetter {
+	return &RestOptionsGetter{}
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -15,14 +17,10 @@ import (
 
 	storagev1alpha1 "github.com/rancher/sbombastic/api/storage/v1alpha1"
 	v1alpha1 "github.com/rancher/sbombastic/api/v1alpha1"
+	"github.com/rancher/sbombastic/internal/handlers"
 )
 
-func EqualReference(img storagev1alpha1.ImageMetadata, registryURI, registryRepository, tag string) bool {
-	return img.RegistryURI == registryURI &&
-		img.Repository == registryRepository &&
-		img.Tag == tag
-}
-
+//nolint:gocognit // Test is complex due to multiple validation steps, acceptable for e2e
 func TestRegistryCreation(t *testing.T) {
 	releaseName := "sbombastic"
 	registryName := "test-registry"
@@ -105,6 +103,70 @@ func TestRegistryCreation(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
+			return ctx
+		}).
+		Assess("Verify the OwnerReference deletion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Get all the VulnerabilityReport/Image/SBOM associated with the Registry
+			labelSelector := labels.FormatLabels(
+				map[string]string{handlers.LabelManagedByKey: handlers.LabelManagedByValue},
+			)
+			images := storagev1alpha1.ImageList{}
+			err := wait.For(conditions.New(cfg.Client().Resources()).ResourceListN(
+				&images,
+				1,
+				resources.WithLabelSelector(labelSelector),
+			))
+			if err != nil {
+				t.Error(err)
+			}
+
+			sboms := storagev1alpha1.SBOMList{}
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceListN(
+				&sboms,
+				1,
+				resources.WithLabelSelector(labelSelector)),
+			)
+			if err != nil {
+				t.Error(err)
+			}
+
+			vulnReports := storagev1alpha1.VulnerabilityReportList{}
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceListN(
+				&vulnReports,
+				1,
+				resources.WithLabelSelector(labelSelector)),
+			)
+			if err != nil {
+				t.Error(err)
+			}
+
+			// Delete the Registry CR
+			registry := &v1alpha1.Registry{
+				ObjectMeta: metav1.ObjectMeta{Name: registryName, Namespace: cfg.Namespace()},
+			}
+			err = cfg.Client().Resources().Delete(ctx, registry)
+			if err != nil {
+				t.Error(err)
+			}
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceDeleted(registry))
+			if err != nil {
+				t.Error(err)
+			}
+
+			// Wait for the VulnerabilityReport/Image/SBOM to be deleted
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourcesDeleted(&images))
+			if err != nil {
+				t.Error(err)
+			}
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourcesDeleted(&sboms))
+			if err != nil {
+				t.Error(err)
+			}
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourcesDeleted(&vulnReports))
+			if err != nil {
+				t.Error(err)
+			}
+
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {


### PR DESCRIPTION
## Description

- Fix https://github.com/rancher-sandbox/sbombastic/issues/182
- Introduce RestOptionsGetter to enable EnableGarbageCollection. 

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #XXX

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff
<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement
Currently, Sbombastic is using SQLite. I'm not sure if we should address the parallel write [issue](https://github.com/mattn/go-sqlite3/issues/1022#issuecomment-1067353980) at this point. 

The common workaround is to limit the number of open connections by calling db.SetMaxOpenConns(1). However, I'm unsure whether this change belongs in this PR.

<!-- Please describe, if any, potential improvement that you are envisioning -->
