### PR TITLE
fix(.dockerignore): include bin directory for Tilt development builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-bin/
 coverage/
 docs/
 examples/


### PR DESCRIPTION
## Description

Tilt wasn't starting since the bin directory contains binaries that Tilt needs to copy into the development Docker image, so it shouldn't be ignored.


