### PR TITLE
test(e2e): export cluster logs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,3 +13,11 @@ jobs:
         with:
           go-version: "1.24.1"
       - run: make test-e2e
+      - name: Upload cluster logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-test-cluster-logs
+          path: test/e2e/logs
+          if-no-files-found: error
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ bin
 
 # Tilt settings
 tilt-settings.yaml
+
+# e2e cluster logs
+test/e2e/logs

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 	)
 
 	testenv.Finish(
+		envfuncs.ExportClusterLogs(kindClusterName, "./logs"),
 		envfuncs.DestroyCluster(kindClusterName),
 	)
 


### PR DESCRIPTION
## Description

Currently, there is no mechanism to debug e2e test failures.
This PR adds support for exporting cluster logs during e2e test runs. 
When the CI workflow fails, the logs are also uploaded as a GitHub Actions artifact.