### PR TITLE
ci(e2e): workaround, fix no space left on device GH action runner error

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.24.1"
-      - name: Run e2e tests
-        run: make test-e2e
       - name: Free up disk space
         # This is a workaround to avoud the "no space left on device" error when pulling the vulbanrability database.
         # We should move to self-hosted runners or enterprise runners to avoid this issue.
@@ -41,6 +39,8 @@ jobs:
           sudo apt-get clean || echo "::warning::The command [sudo apt-get clean] failed to complete successfully. Proceeding..."
           # Remove docker images
           sudo docker image prune --all --force || true
+      - name: Run e2e tests
+        run: make test-e2e
       - name: Upload cluster logs
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,35 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.24.1"
-      - run: make test-e2e
+      - name: Run e2e tests
+        run: make test-e2e
+      - name: Free up disk space
+        # This is a workaround to avoud the "no space left on device" error when pulling the vulbanrability database.
+        # We should move to self-hosted runners or enterprise runners to avoid this issue.
+        # The free space script is based on https://github.community/t/bigger-github-hosted-runners-disk-space/17267/11
+        # and https://github.com/jlumbroso/free-disk-space/blob/main/action.yml
+        run: |
+          # Android SDK
+          sudo rm -rf /usr/local/lib/android || true
+          # .NET runtime
+          sudo rm -rf /usr/share/dotnet || true
+          # Haskell runtime
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          # Remove large packages
+          sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y '^llvm-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^llvm-.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
+          sudo apt-get clean || echo "::warning::The command [sudo apt-get clean] failed to complete successfully. Proceeding..."
+          # Remove docker images
+          sudo docker image prune --all --force || true
       - name: Upload cluster logs
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Description

This is a temporary workaround to address the "no space left on device" error documented in issue #228.
The error occurs when pulling the vulnerability database during e2e test execution.

The free space script is based on https://github.community/t/bigger-github-hosted-runners-disk-space/17267/11
and https://github.com/jlumbroso/free-disk-space/blob/main/action.yml. 
We are not using the action directly because it is not included in Rancher's allowed actions list.

We should consider transitioning to self-hosted or enterprise runners, especially since the situation will likely worsen once multiscanner support is introduced.


Fixes #228 


