### PR TITLE
ci(codecov): add threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
## Description

Adds a 1% threshold to account for variability in coverage due to asynchronous integration tests, where timing can affect results.

See failure: https://app.codecov.io/gh/rancher-sandbox/sbombastic/commit/ddde76191d8a85cba0feb37f228060b92e8bb564