### PR TITLE
ci: automate the helm chart release

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,0 +1,38 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: "release"
+  cancel-in-progress: false
+
+jobs:
+  release:
+    permissions:
+      contents: write # chart-releaser needs to release the charts to the repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,3 +98,10 @@ jobs:
               prerelease: isPreRelease,
               make_latest: !isPreRelease
             });
+  update-charts:
+    needs: [create-release]
+    uses: ./.github/workflows/update-charts.yml
+    permissions:
+      contents: write # for updatecli to update the repository
+      pull-requests: write # for updatecli to create a PR
+    secrets: inherit

--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -1,0 +1,22 @@
+name: Update helm charts
+on:
+  workflow_call:
+jobs:
+  update-sbombastic-charts:
+    name: Update SBOMbastic charts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for updatecli to update the repository
+      pull-requests: write # for updatecli to create a PR
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@307ce72e224b82157cc31c78828f168b8e55d47d # v2.84.0
+
+      - name: Update SBOMbastic charts
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: "updatecli apply --config ./updatecli/updatecli.d/helm-chart-update.yaml --values updatecli/values.yaml"

--- a/updatecli/updatecli.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.d/helm-chart-update.yaml
@@ -1,0 +1,103 @@
+name: Update SBOMbastic chart versions
+
+sources:
+  chartVersion:
+    name: "Get latest sbombastic helm version"
+    kind: yaml
+    transformers:
+      - semverinc: patch
+    spec:
+      file: charts/sbombastic/Chart.yaml
+      key: $.version
+  releaseVersion:
+    name: "Get latest sbombastic version"
+    kind: githubrelease
+    spec:
+      owner: '{{ requiredEnv .github.owner }}'
+      repository: sbombastic
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "semver"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      directory: "/tmp/helm-charts"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "sbombastic"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitmessage:
+        type: "chore"
+        title: "Update SBOMbastic Helm charts"
+        hidecredit: true
+        footers: "Signed-off-by: SBOMbastic bot."
+
+actions:
+  default:
+    title: 'chore: Helm chart {{ source "releaseVersion" }} release'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Helm chart {{ source "releaseVersion" }} update.
+        This PR has been created by the automation used to automatically update the Helm charts when SBOMbastic is released or helm chart content is updated.
+        REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
+      draft: false
+      labels:
+        - "chore"
+
+targets:
+  update_helm_version:
+    scmid: default
+    name: Update Helm chart version
+    kind: yaml
+    sourceid: chartVersion
+    spec:
+      file: charts/sbombastic/Chart.yaml
+      key: $.version
+  update_annotations_upstream_version:
+    scmid: default
+    name: Update Helm chart annotations upstream version
+    kind: yaml
+    sourceid: releaseVersion
+    spec:
+      file: charts/sbombastic/Chart.yaml
+      key: $.annotations.catalog\.cattle\.io/upstream-version
+  update_appversion:
+    scmid: default
+    name: Update Helm chart appVersion
+    kind: yaml
+    sourceid: releaseVersion
+    spec:
+      file: charts/sbombastic/Chart.yaml
+      key: $.appVersion
+  update_controller_version:
+    scmid: default
+    name: Update Helm chart controller version
+    kind: yaml
+    sourceid: releaseVersion
+    spec:
+      file: charts/sbombastic/values.yaml
+      key: $.controller.image.tag
+  update_storage_version:
+    scmid: default
+    name: Update Helm chart storage version
+    kind: yaml
+    sourceid: releaseVersion
+    spec:
+      file: charts/sbombastic/values.yaml
+      key: $.storage.image.tag
+  update_worker_version:
+    scmid: default
+    name: Update Helm chart worker version
+    kind: yaml
+    sourceid: releaseVersion
+    spec:
+      file: charts/sbombastic/values.yaml
+      key: $.worker.image.tag

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,6 @@
+github:
+  owner: "UPDATECLI_GITHUB_OWNER"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  author: "SBOMbastic bot"
+  user: "UPDATECLI_GITHUB_OWNER"


### PR DESCRIPTION
## Description
- Fix https://github.com/rancher-sandbox/sbombastic/issues/212
- When release, it will automatically bump helm version
- Use updatecli to bump the helm version, including appversion/annotation/version.

## Test

- create a fake release, ensure it generate the [PR](https://github.com/pohanhuangtw/sbombastic/pull/144) define the helm version bump based on the [sbombastic-update.yaml
](https://github.com/rancher-sandbox/sbombastic/blob/c66860f65fd20d6625342d7ca8b56d27bc140e3d/updatecli/updatecli.d/sbombastic-update.yaml)
- create a bump from the chart, ensure the [github page](https://pohanhuangtw.github.io/sbombastic/) update.
- Ensure the helm repo is searchable and addable
```bash
helm repo add sbombastic-po https://pohanhuangtw.github.io/sbombastic
helm repo update
"sbombastic-po" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "sbombastic-po" chart repository
...Successfully got an update from the "yunikorn" chart repository
...Successfully got an update from the "neuvector" chart repository
...Successfully got an update from the "nats" chart repository
Update Complete. ⎈Happy Helming!⎈

helm search repo sbombastic-po -l
NAME                    	CHART VERSION	APP VERSION	DESCRIPTION                 
sbombastic-po/sbombastic	0.1.1        	v0.0.3     	A Helm chart for Kubernetes 
sbombastic-po/sbombastic	0.1.0        	v0.0.2     	A Helm chart for Kubernetes 
```  

## Demo
- Helm version bump [PR](https://github.com/pohanhuangtw/sbombastic/pull/150).
- Helm [release](https://github.com/pohanhuangtw/sbombastic/releases/tag/sbombastic-0.1.1)

## TODO
- [x] Readme improvement [Issue #252](https://github.com/rancher-sandbox/sbombastic/issues/252)
  - Reduce the size of the SBOMbastic Storage component
  - Fix the broken source code link in the README

- [x] [move helm chart](https://github.com/rancher-sandbox/sbombastic/issues/255)