### PR TITLE
fix: correct broken source link and adjust heading levels

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,4 +1,4 @@
-# SBOMbastic Storage
+## SBOMbastic Storage
 
 The `storage` Helm chart installs the SBOMbastic storage deployment, which should be installed alongside the SBOMbastic controller and worker components.
 

--- a/helm/app-readme.md
+++ b/helm/app-readme.md
@@ -20,4 +20,4 @@ SBOMbastic is a SBOM-centric security scanner for Kubernetes. It provides native
 
 ## Learn More
 
-- [Source Code](https://github.com/rancher-box/sbombastic)
+- [Source Code](https://github.com/rancher-sandbox/sbombastic)


### PR DESCRIPTION
## Description

- Fix https://github.com/rancher-sandbox/sbombastic/issues/252
- source link should be rancher-sandbox not rancher-box
- heading for readme should be H2

## Related PR
- https://github.com/rancher-sandbox/sbombastic/pull/251