### PR TITLE
chore: tune code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,9 @@ coverage:
     project:
       default:
         threshold: 1%
+ignore:
+  - pkg
+  - cmd
+  - api/storage/insatll
+  - api/storage/v1alpha1/zz_generated.deepcopy.go
+  - api/v1alpha1


### PR DESCRIPTION
## Description
- Fix https://github.com/rancher-sandbox/sbombastic/issues/201
- Ignore the generated code like deepcopy.go, and *.go generated for worker pod
- Ignore cmd/ because it only contains main, and flag parsing
- Ignore api/storage/install: only registers types to scheme
- Ignore api/v1alpha1: only contains init and generated deepcopy code

