### PR TITLE
fix: add permission when calling attestion generation

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -122,6 +122,9 @@ jobs:
     needs: [merge]
     if: ${{ inputs.version }}
     uses: ./.github/workflows/attestation.yml
+    permissions:
+      id-token: write # Generating OIDC token for Sigstore/Cosign authentication
+      packages: write # Pushing attestations to container registry
     strategy:
       matrix:
         component: [controller, worker, storage]


### PR DESCRIPTION
## Description
- Fix https://github.com/orgs/rancher-sandbox/projects/6/views/1?pane=issue&itemId=115855835&issue=rancher-sandbox%7Csbombastic%7C259
- Use the proper permission to call attestation generation workflow
- To resolve error in [workflows](https://github.com/rancher-sandbox/sbombastic/actions/runs/15734899509)