### PR TITLE
fix: container build merge manifest

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -14,8 +14,8 @@ jobs:
   attest:
     name: Sign attestations and upload as artifacts
     permissions:
-      packages: write
-      id-token: write
+      packages: write # Uploading signed artifacts to ghcr.io
+      id-token: write # Signing images with cosign
     runs-on: ubuntu-latest
     env:
       CRANE_VERSION: v0.20.5

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -23,14 +23,11 @@ jobs:
             runner: ubuntu-24.04-arm
             platform: linux/arm64
     permissions:
-      packages: write
-      id-token: write # to mint the OIDC token for Sigstore signatures
+      packages: write # Pushing images to ghcr.io
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install cosign
-        uses: sigstore/cosign-installer@fb28c2b6339dcd94da6e4cbcbc5e888961f6f8c3 # v3.9.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Login to GitHub Container Registry
@@ -73,6 +70,8 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      packages: write # Pushing multi-arch manifest to ghcr.io
     strategy:
       matrix:
         component: [controller, worker, storage]
@@ -124,7 +123,7 @@ jobs:
     uses: ./.github/workflows/attestation.yml
     permissions:
       id-token: write # Generating OIDC token for Sigstore/Cosign authentication
-      packages: write # Pushing attestations to container registry
+      packages: write # Pushing attestations to ghcr.io
     strategy:
       matrix:
         component: [controller, worker, storage]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,17 @@ on:
 
 jobs:
   build:
+    permissions:
+      packages: write # Pushing images to ghcr.io
+      id-token: write # Signing images with cosign
     uses: ./.github/workflows/container-build.yaml
     with:
       version: ${{ github.ref_name }}
     secrets: inherit
   create-release:
     needs: [build]
+    permissions:
+      contents: write # Creating a release
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve tag name


### PR DESCRIPTION
## Description
- Fix the permisssion across the repo.
- build require packages: write, same for merge
- add content: write for release.

## Demo
- [fork release workflow](https://github.com/pohanhuangtw/sbombastic/actions/runs/15756415755) and mock [release](https://github.com/pohanhuangtw/sbombastic/releases/tag/v0.0.1), need to manually create the release draft
- [fork merge workflow ](https://github.com/pohanhuangtw/sbombastic/actions/runs/15756277911)and merge [publish](https://github.com/pohanhuangtw/sbombastic/pkgs/container/sbombastic%2Fcontroller) images