### PR TITLE
feat(controller): add ScanJob reconciler

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -456,6 +456,13 @@ linters:
       - text: 'comment on exported \S+ \S+ should be of the form ".+"'
         source: "// ?(nolint|TODO)"
         linters: [revive, staticcheck]
+      # Disable the 'unparam' warning "result 0 ... is always nil" in internal/controller.
+      # Controller methods often return a zero-valued ctrl.Result even if unused,
+      # so this suppresses noise in idiomatic code without disabling 'unparam' globally.
+      - path: ^internal/controller/.*\.go$
+        linters:
+          - unparam
+        text: "result 0.*is always nil"
       - path: '_test\.go'
         linters:
           - bodyclose
@@ -466,3 +473,7 @@ linters:
           - gosec
           - noctx
           - wrapcheck
+      - path: '_test\.go'
+        linters:
+          - revive
+        text: "dot-imports"

--- a/api/v1alpha1/scanjob_types.go
+++ b/api/v1alpha1/scanjob_types.go
@@ -162,7 +162,7 @@ func (s *ScanJob) MarkFailed(reason, message string) {
 
 // IsInProgress returns true if the job is running.
 func (s *ScanJob) IsInProgress() bool {
-	return !s.IsComplete() && !s.IsFailed()
+	return !s.IsComplete() && !s.IsFailed() && s.Status.StartTime != nil
 }
 
 // IsComplete returns true if the job has completed successfully.

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -223,6 +223,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controller.ScanJobReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Publisher: publisher,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ScanJob")
+		os.Exit(1)
+	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/helm/templates/controller/role.yaml
+++ b/helm/templates/controller/role.yaml
@@ -11,6 +11,7 @@ rules:
   - sbombastic.rancher.io
   resources:
   - registries
+  - scanjobs
   verbs:
   - create
   - delete
@@ -23,12 +24,14 @@ rules:
   - sbombastic.rancher.io
   resources:
   - registries/finalizers
+  - scanjobs/finalizers
   verbs:
   - update
 - apiGroups:
   - sbombastic.rancher.io
   resources:
   - registries/status
+  - scanjobs/status
   verbs:
   - get
   - patch

--- a/helm/templates/crd/sbombastic.rancher.io_scanjobs.yaml
+++ b/helm/templates/crd/sbombastic.rancher.io_scanjobs.yaml
@@ -49,7 +49,7 @@ spec:
             description: ScanJobStatus defines the observed state of ScanJob.
             properties:
               completionTime:
-                description: CompletionTime is when the job completed or failed
+                description: CompletionTime is when the job completed or failed.
                 format: date-time
                 type: string
               conditions:
@@ -118,8 +118,7 @@ spec:
                   been scanned.
                 type: integer
               startTime:
-                description: StartTime is when the job began processing (not just
-                  queued)
+                description: StartTime is when the job started processing.
                 format: date-time
                 type: string
             type: object

--- a/internal/controller/image_controller_test.go
+++ b/internal/controller/image_controller_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"encoding/json"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:revive // Required for testing
-	. "github.com/onsi/gomega"    //nolint:revive // Required for testing
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/google/uuid"

--- a/internal/controller/registry_controller_test.go
+++ b/internal/controller/registry_controller_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2" //nolint:revive // Required for testing
-	. "github.com/onsi/gomega"    //nolint:revive // Required for testing
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/internal/controller/sbom_controller_test.go
+++ b/internal/controller/sbom_controller_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"encoding/json"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:revive // Required for testing
-	. "github.com/onsi/gomega"    //nolint:revive // Required for testing
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/google/uuid"

--- a/internal/controller/scanjob_controller.go
+++ b/internal/controller/scanjob_controller.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	sbombasticv1alpha1 "github.com/rancher/sbombastic/api/v1alpha1"
+	"github.com/rancher/sbombastic/internal/handlers"
+	"github.com/rancher/sbombastic/internal/messaging"
+)
+
+// ScanJobReconciler reconciles a ScanJob object
+type ScanJobReconciler struct {
+	client.Client
+	Scheme    *runtime.Scheme
+	Publisher messaging.Publisher
+}
+
+// +kubebuilder:rbac:groups=sbombastic.rancher.io,resources=scanjobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=sbombastic.rancher.io,resources=scanjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sbombastic.rancher.io,resources=scanjobs/finalizers,verbs=update
+
+// Reconcile reconciles a ScanJob object.
+func (r *ScanJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	log.Info("Reconciling ScanJob")
+
+	scanJob := &sbombasticv1alpha1.ScanJob{}
+	if err := r.Get(ctx, req.NamespacedName, scanJob); err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found, likely already deleted
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("unable to get ScanJob: %w", err)
+	}
+
+	// Check if resource is being deleted
+	if !scanJob.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	if scanJob.IsFailed() || scanJob.IsComplete() || scanJob.IsInProgress() {
+		return ctrl.Result{}, nil
+	}
+
+	original := scanJob.DeepCopy()
+
+	scanJob.InitializeConditions()
+
+	reconcileResult, reconcileErr := r.reconcileScanJob(ctx, scanJob)
+
+	// Update status if it changed
+	if !equality.Semantic.DeepEqual(original.Status, scanJob.Status) {
+		log.Info("Updating ScanJob status")
+		if err := r.Status().Patch(ctx, scanJob, client.MergeFrom(original)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update ScanJob status: %w", err)
+		}
+	}
+
+	return reconcileResult, reconcileErr
+}
+
+// reconcileScanJob implements the actual reconciliation logic.
+func (r *ScanJobReconciler) reconcileScanJob(ctx context.Context, scanJob *sbombasticv1alpha1.ScanJob) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	registry := &sbombasticv1alpha1.Registry{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      scanJob.Spec.Registry,
+		Namespace: scanJob.Namespace,
+	}, registry); err != nil {
+		if errors.IsNotFound(err) {
+			log.Error(err, "Registry not found", "registry", scanJob.Spec.Registry)
+			scanJob.MarkFailed(sbombasticv1alpha1.ReasonRegistryNotFound, fmt.Sprintf("Registry %s not found", scanJob.Spec.Registry))
+
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, fmt.Errorf("unable to get Registry %s: %w", scanJob.Spec.Registry, err)
+	}
+
+	registryData, err := json.Marshal(registry)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to marshal registry data: %w", err)
+	}
+	scanJob.Annotations = map[string]string{
+		sbombasticv1alpha1.RegistryAnnotation: string(registryData),
+	}
+
+	if err = r.Update(ctx, scanJob); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update ScanJob with registry data: %w", err)
+	}
+
+	scanJob.MarkInProgress(sbombasticv1alpha1.ReasonProcessing, "Processing scan job")
+
+	message, err := json.Marshal(&handlers.CreateCatalogMessage{})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to marshal CreateCatalog message: %w", err)
+	}
+
+	if err := r.Publisher.Publish(ctx, handlers.CreateCatalogSubject, message); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to publish CreateSBOM message: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&sbombasticv1alpha1.ScanJob{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 10,
+		}).
+		Complete(r)
+	if err != nil {
+		return fmt.Errorf("failed to create ScanJob controller: %w", err)
+	}
+
+	return nil
+}

--- a/internal/controller/scanjob_controller_test.go
+++ b/internal/controller/scanjob_controller_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	sbombasticv1alpha1 "github.com/rancher/sbombastic/api/v1alpha1"
+	"github.com/rancher/sbombastic/internal/handlers"
+	messagingMocks "github.com/rancher/sbombastic/internal/messaging/mocks"
+)
+
+var _ = Describe("ScanJob Controller", func() {
+	When("A ScanJob is created with a valid Registry", func() {
+		var reconciler ScanJobReconciler
+		var scanJob sbombasticv1alpha1.ScanJob
+		var registry sbombasticv1alpha1.Registry
+		var mockPublisher *messagingMocks.MockPublisher
+
+		BeforeEach(func(ctx context.Context) {
+			By("Creating a new ScanJobReconciler")
+			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
+			reconciler = ScanJobReconciler{
+				Client:    k8sClient,
+				Publisher: mockPublisher,
+			}
+
+			By("Creating a Registry")
+			registry = sbombasticv1alpha1.Registry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-registry",
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.RegistrySpec{
+					URI: "https://registry.example.com",
+				},
+			}
+			Expect(k8sClient.Create(ctx, &registry)).To(Succeed())
+
+			By("Creating a ScanJob")
+			scanJob = sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      uuid.New().String(),
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: registry.Name,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &scanJob)).To(Succeed())
+		})
+
+		It("should successfully reconcile and publish CreateCatalog message", func(ctx context.Context) {
+			By("Setting up the expected message publication")
+			message, err := json.Marshal(&handlers.CreateCatalogMessage{})
+			Expect(err).NotTo(HaveOccurred())
+			mockPublisher.On("Publish", mock.Anything, handlers.CreateCatalogSubject, message).Return(nil)
+
+			By("Reconciling the ScanJob")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      scanJob.Name,
+					Namespace: scanJob.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the ScanJob was updated with registry data")
+			updatedScanJob := &sbombasticv1alpha1.ScanJob{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      scanJob.Name,
+				Namespace: scanJob.Namespace,
+			}, updatedScanJob)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that registry data was stored in annotations")
+			registryData, exists := updatedScanJob.Annotations[sbombasticv1alpha1.RegistryAnnotation]
+			Expect(exists).To(BeTrue())
+
+			var storedRegistry sbombasticv1alpha1.Registry
+			err = json.Unmarshal([]byte(registryData), &storedRegistry)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(storedRegistry.Name).To(Equal(registry.Name))
+
+			By("Verifying the ScanJob is marked as in progress")
+			Expect(updatedScanJob.IsInProgress()).To(BeTrue())
+
+			By("Verifying the message was published")
+			mockPublisher.AssertExpectations(GinkgoT())
+		})
+	})
+
+	When("A ScanJob references a non-existent Registry", func() {
+		var reconciler ScanJobReconciler
+		var scanJob sbombasticv1alpha1.ScanJob
+		var mockPublisher *messagingMocks.MockPublisher
+
+		BeforeEach(func(ctx context.Context) {
+			By("Creating a new ScanJobReconciler")
+			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
+			reconciler = ScanJobReconciler{
+				Client:    k8sClient,
+				Publisher: mockPublisher,
+			}
+
+			By("Creating a ScanJob with non-existent Registry")
+			scanJob = sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      uuid.New().String(),
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: "non-existent-registry",
+				},
+			}
+			Expect(k8sClient.Create(ctx, &scanJob)).To(Succeed())
+		})
+
+		It("should mark the ScanJob as failed", func(ctx context.Context) {
+			By("Reconciling the ScanJob")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      scanJob.Name,
+					Namespace: scanJob.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the ScanJob is marked as failed")
+			updatedScanJob := &sbombasticv1alpha1.ScanJob{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      scanJob.Name,
+				Namespace: scanJob.Namespace,
+			}, updatedScanJob)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedScanJob.IsFailed()).To(BeTrue())
+
+			By("Verifying no message was published")
+			mockPublisher.AssertNotCalled(GinkgoT(), "Publish")
+		})
+	})
+
+	When("A ScanJob is already completed", func() {
+		var reconciler ScanJobReconciler
+		var scanJob sbombasticv1alpha1.ScanJob
+		var mockPublisher *messagingMocks.MockPublisher
+
+		BeforeEach(func(ctx context.Context) {
+			By("Creating a new ScanJobReconciler")
+			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
+			reconciler = ScanJobReconciler{
+				Client:    k8sClient,
+				Publisher: mockPublisher,
+			}
+
+			By("Creating a completed ScanJob")
+			scanJob = sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      uuid.New().String(),
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: "test-registry",
+				},
+			}
+			Expect(k8sClient.Create(ctx, &scanJob)).To(Succeed())
+
+			By("Marking the ScanJob as completed")
+			scanJob.MarkComplete(sbombasticv1alpha1.ReasonAllImagesScanned, "Scan completed successfully")
+			Expect(k8sClient.Status().Update(ctx, &scanJob)).To(Succeed())
+		})
+
+		It("should not process the ScanJob", func(ctx context.Context) {
+			By("Reconciling the ScanJob")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      scanJob.Name,
+					Namespace: scanJob.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying no message was published")
+			mockPublisher.AssertNotCalled(GinkgoT(), "Publish")
+		})
+	})
+})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -22,8 +22,8 @@ import (
 	"runtime"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:revive // Required for testing
-	. "github.com/onsi/gomega"    //nolint:revive // Required for testing
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
## Description

Adds the `ScanJob` reconciler.
When a `ScanJob` is created, if the target of the `ScanJob` Registry exists in the same namespace, a `CreateCatalog ' message is sent to the queue. 

Part of: #269 
