### PR TITLE
fix: add email in footer to pass DCO

### DIFF
--- a/updatecli/updatecli.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.d/helm-chart-update.yaml
@@ -34,7 +34,7 @@ scms:
         type: "chore"
         title: "Update SBOMbastic Helm charts"
         hidecredit: true
-        footers: "Signed-off-by: SBOMbastic bot."
+        footers: "Signed-off-by: SBOMbastic bot <sbombastic-bot@users.noreply.github.com>"
 
 actions:
   default:


### PR DESCRIPTION
## Description
- Fix https://github.com/rancher-sandbox/sbombastic/pull/274
- In current updatecli commit footer, the email is not added, therefore it failed at DCO test.
