### PR TITLE
chore: change helm release name

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -34,5 +34,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        with:
+          config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,1 @@
+release-name-template: "{{.Name}}-chart-{{.Version}}"

--- a/updatecli/updatecli.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.d/helm-chart-update.yaml
@@ -39,14 +39,14 @@ scms:
 
 actions:
   default:
-    title: 'chore: Helm chart {{ source "releaseVersion" }} release'
+    title: 'chore: Helm chart {{ source "chartVersion" }} release'
     kind: github/pullrequest
     scmid: default
     spec:
       automerge: false
       mergemethod: squash
       description: |
-        Automatic Helm chart {{ source "releaseVersion" }} update.
+        Automatic Helm chart {{ source "chartVersion" }} update.
         This PR has been created by the automation used to automatically update the Helm charts when SBOMbastic is released or helm chart content is updated.
         REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
       draft: false


### PR DESCRIPTION
## Description
- Fix release naming
- PR naming

## Demo from fork
- helm chart [PR](https://github.com/pohanhuangtw/sbombastic/pull/28) update from updatecli 
<img width="728" alt="Screenshot 2025-06-25 at 2 33 18 PM" src="https://github.com/user-attachments/assets/91e1f812-21a3-4c4c-97aa-a3f635723584" />

- [Release](https://github.com/pohanhuangtw/sbombastic/releases/tag/sbombastic-chart-0.1.0)
<img width="739" alt="Screenshot 2025-06-25 at 2 33 24 PM" src="https://github.com/user-attachments/assets/7bf583fb-e451-4cd6-a601-97f8096a1679" />

