### PR TITLE
fix(worker): skip trivy version check and disable telemetry

### DIFF
--- a/internal/handlers/generate_sbom.go
+++ b/internal/handlers/generate_sbom.go
@@ -99,6 +99,8 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message []byte) error 
 	app := trivyCommands.NewApp()
 	app.SetArgs([]string{
 		"image",
+		"--skip-version-check",
+		"--disable-telemetry",
 		"--cache-dir", h.workDir,
 		"--format", "spdx-json",
 		"--db-repository", "public.ecr.aws/aquasecurity/trivy-db",

--- a/internal/handlers/scan_sbom.go
+++ b/internal/handlers/scan_sbom.go
@@ -108,6 +108,8 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message []byte) error { //
 	app := trivyCommands.NewApp()
 	app.SetArgs([]string{
 		"sbom",
+		"--skip-version-check",
+		"--disable-telemetry",
 		"--cache-dir", h.workDir,
 		"--format", "sarif",
 		// Use the public ECR repository to bypass GitHub's rate limits.


### PR DESCRIPTION
## Description

The CI is currently failing due to a race condition in the Trivy codebase:
[https://github.com/rancher-sandbox/sbombastic/actions/runs/16072290738/job/45359464452#step:4:143](https://github.com/rancher-sandbox/sbombastic/actions/runs/16072290738/job/45359464452#step:4:143)

Since we don't require Trivy to perform version checks or send telemetry, this PR disables both features by adding the appropriate flags.
