### PR TITLE
feat: support rancher global registry setting

### DIFF
--- a/charts/sbombastic/templates/_helpers.tpl
+++ b/charts/sbombastic/templates/_helpers.tpl
@@ -30,6 +30,14 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Common labels
 */}}

--- a/charts/sbombastic/templates/controller/deployment.yaml
+++ b/charts/sbombastic/templates/controller/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             {{- if .Values.controller.logLevel }}
             - -log-level={{ .Values.controller.logLevel }}
             {{- end }}
-          image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+          image: '{{ template "system_default_registry" . }}{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}'
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           name: controller
           securityContext:

--- a/charts/sbombastic/templates/storage/deployment.yaml
+++ b/charts/sbombastic/templates/storage/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ include "sbombastic.fullname" . }}-storage
       containers:
         - name: storage
-          image: {{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}
+          image: '{{ template "system_default_registry" . }}{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}'
           securityContext:
             {{ include "sbombastic.securityContext" . | nindent 12 }}
           args:

--- a/charts/sbombastic/templates/worker/deployment.yaml
+++ b/charts/sbombastic/templates/worker/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ include "sbombastic.fullname" . }}-worker
       containers:
         - name: worker
-          image: {{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}
+          image: '{{ template "system_default_registry" . }}{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}'
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           securityContext:
             {{ include "sbombastic.securityContext" . | nindent 12 }}

--- a/charts/sbombastic/tests/controller/deployment_test.yaml
+++ b/charts/sbombastic/tests/controller/deployment_test.yaml
@@ -4,11 +4,14 @@ templates:
 tests:
   - it: "should render a Deployment with the correct replica count, logging level, image, and imagePullPolicy"
     set:
+      global:
+        cattle:
+          systemDefaultRegistry: rancher.io
       controller:
         replicas: 5
         logLevel: debug
         image:
-          repository: ghcr.io/rancher-sandbox/sbombastic/controller
+          repository: rancher-sandbox/sbombastic/controller
           tag: v0.1.0
           pullPolicy: Always
     asserts:
@@ -17,7 +20,7 @@ tests:
           value: 5
       - equal:
           path: "spec.template.spec.containers[0].image"
-          value: "ghcr.io/rancher-sandbox/sbombastic/controller:v0.1.0"
+          value: "rancher.io/rancher-sandbox/sbombastic/controller:v0.1.0"
       - equal:
           path: "spec.template.spec.containers[0].imagePullPolicy"
           value: "Always"

--- a/charts/sbombastic/tests/storage/deployment_test.yaml
+++ b/charts/sbombastic/tests/storage/deployment_test.yaml
@@ -6,11 +6,14 @@ templates:
 tests:
   - it: "should render a Deployment with the correct replica count, logging level, image, and imagePullPolicy"
     set:
+      global:
+        cattle:
+          systemDefaultRegistry: rancher.io
       storage:
         replicas: 5
         logLevel: debug
         image:
-          repository: ghcr.io/rancher-sandbox/sbombastic/storage
+          repository: rancher-sandbox/sbombastic/storage
           tag: v0.1.0
           pullPolicy: Always
         persistence:
@@ -21,7 +24,7 @@ tests:
           value: 5
       - equal:
           path: "spec.template.spec.containers[0].image"
-          value: "ghcr.io/rancher-sandbox/sbombastic/storage:v0.1.0"
+          value: "rancher.io/rancher-sandbox/sbombastic/storage:v0.1.0"
       - equal:
           path: "spec.template.spec.containers[0].imagePullPolicy"
           value: "Always"

--- a/charts/sbombastic/tests/worker/deployment_test.yaml
+++ b/charts/sbombastic/tests/worker/deployment_test.yaml
@@ -6,11 +6,14 @@ templates:
 tests:
   - it: "should render a Deployment with the correct replica count, logging level, image, and imagePullPolicy"
     set:
+      global:
+        cattle:
+          systemDefaultRegistry: rancher.io
       worker:
         replicas: 5
         logLevel: debug
         image:
-          repository: ghcr.io/rancher-sandbox/sbombastic/worker
+          repository: rancher-sandbox/sbombastic/worker
           tag: v0.1.0
           pullPolicy: Always
     asserts:
@@ -19,7 +22,7 @@ tests:
           value: 5
       - equal:
           path: "spec.template.spec.containers[0].image"
-          value: "ghcr.io/rancher-sandbox/sbombastic/worker:v0.1.0"
+          value: "rancher.io/rancher-sandbox/sbombastic/worker:v0.1.0"
       - equal:
           path: "spec.template.spec.containers[0].imagePullPolicy"
           value: "Always"

--- a/charts/sbombastic/values.yaml
+++ b/charts/sbombastic/values.yaml
@@ -2,26 +2,31 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# NOTE: This section is used to configure the global settings for the sbombastic chart.
+global:
+  cattle:
+    systemDefaultRegistry: ghcr.io
+
 controller:
   image:
-    repository: ghcr.io/rancher-sandbox/sbombastic/controller
-    tag: v0.1.0-alpha1
+    repository: rancher-sandbox/sbombastic/controller
+    tag: "v0.1.0-alpha1"
     pullPolicy: IfNotPresent
   replicas: 3
   logLevel: "info"
 
 storage:
   image:
-    repository: ghcr.io/rancher-sandbox/sbombastic/storage
-    tag: v0.1.0-alpha1
+    repository: rancher-sandbox/sbombastic/storage
+    tag: "v0.1.0-alpha1"
     pullPolicy: IfNotPresent
   replicas: 1
   # logLevel: "debug" //TODO: uncomment this, when the log parser in storage is implemented
 
 worker:
   image:
-    repository: ghcr.io/rancher-sandbox/sbombastic/worker
-    tag: v0.1.0-alpha1
+    repository: rancher-sandbox/sbombastic/worker
+    tag: "v0.1.0-alpha1"
     pullPolicy: IfNotPresent
   replicas: 3
   logLevel: "info"


### PR DESCRIPTION
## Description
- Fix https://github.com/rancher-sandbox/sbombastic/issues/309
- ensure the registry setting from global.cattle.systemDefaultRegistry only
- ensure  the tag use chart appVersion as default if tag in value is empty.
## Test

- make helm-unittest