### PR TITLE
feat: helm cnpg integration

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Add Helm dependency repos
         run: |
           helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+          helm repo add cnpg https://cloudnative-pg.io/charts/
 
       - name: Release Helm charts
         shell: bash

--- a/charts/sbombastic/Chart.lock
+++ b/charts/sbombastic/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.3.7
 digest: sha256:8043b9037b1e01203912f54c20c1919fb3fe0a7503099b77fb0de2785559960a
-generated: "2025-05-29T16:30:48.470934699+02:00"
+generated: "2025-07-15T04:53:51.603452078Z"

--- a/charts/sbombastic/templates/_helpers.tpl
+++ b/charts/sbombastic/templates/_helpers.tpl
@@ -74,6 +74,7 @@ Create the name of the service account to use
 Security Contexts
 */}}
 {{- define "sbombastic.securityContext" -}}
+{{- if .Values.security.harden_deployment }}
 readOnlyRootFilesystem: true
 runAsNonRoot: true
 runAsUser: 65532
@@ -83,4 +84,10 @@ allowPrivilegeEscalation: false
 capabilities:
     drop:
     - "ALL"
+{{- else }}
+allowPrivilegeEscalation: false
+capabilities:
+    drop:
+    - "ALL"
+{{- end }}
 {{- end}}

--- a/charts/sbombastic/templates/storage/database/cnpg/cert-manager.yaml
+++ b/charts/sbombastic/templates/storage/database/cnpg/cert-manager.yaml
@@ -1,0 +1,130 @@
+{{ if .Values.storage.database.enableBuiltInCnpg }}
+# Note: this setup inspired by https://cloudnative-pg.io/documentation/current/samples/cluster-example-cert-manager.yaml
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-server-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  commonName: {{ include "sbombastic.fullname" . }}-selfsigned-cnpg-server-ca
+  secretName: {{ include "sbombastic.fullname" . }}-cnpg-server-ca-key-pair
+  duration: 8736h
+  renewBefore: 240h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ include "sbombastic.fullname" . }}-cnpg-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-server-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ include "sbombastic.fullname" . }}-cnpg-server-ca-key-pair
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-server-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    cnpg.io/reload: ""
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-server-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "sbombastic.fullname" . }}-cnpg-server-cert
+  usages:
+    - server auth
+  dnsNames:
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-rw
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-rw.{{ .Release.Namespace }}
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-rw.{{ .Release.Namespace }}.svc
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-rw.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-r
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-r.{{ .Release.Namespace }}
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-r.{{ .Release.Namespace }}.svc
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-r.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-ro
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-ro.{{ .Release.Namespace }}
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-ro.{{ .Release.Namespace }}.svc
+    - {{ .Values.storage.database.cnpg.fullnameOverride }}-ro.{{ .Release.Namespace }}.svc.cluster.local
+
+  duration: 2160h
+  renewBefore: 240h
+  issuerRef:
+    name: {{ include "sbombastic.fullname" . }}-cnpg-server-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-client-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  commonName: {{ include "sbombastic.fullname" . }}-selfsigned-cnpg-client-ca
+  secretName: {{ include "sbombastic.fullname" . }}-cnpg-client-ca-key-pair
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  duration: 8736h
+  renewBefore: 240h
+  issuerRef:
+    name: {{ include "sbombastic.fullname" . }}-cnpg-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-client-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ include "sbombastic.fullname" . }}-cnpg-client-ca-key-pair
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-client-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    cnpg.io/reload: ""
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-cnpg-client-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "sbombastic.fullname" . }}-cnpg-client-cert
+  commonName: sbombastic
+  usages:
+    - client auth
+  duration: 2160h
+  renewBefore: 240h
+  issuerRef:
+    name: {{ include "sbombastic.fullname" . }}-cnpg-client-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- end }}

--- a/charts/sbombastic/templates/storage/database/cnpg/cluster.yaml
+++ b/charts/sbombastic/templates/storage/database/cnpg/cluster.yaml
@@ -1,0 +1,30 @@
+{{ if .Values.storage.database.enableBuiltInCnpg }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Values.storage.database.cnpg.fullnameOverride }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  instances: {{ .Values.storage.database.cnpg.cluster.instances }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.storage.database.cnpg.cluster.initdb.database }}
+      owner: {{ .Values.storage.database.cnpg.cluster.initdb.owner }}
+      secret:
+        name: "" # cnpg will create a secret with the name of the database owner
+
+  postgresql:
+    pg_hba:
+      - hostssl all all 0.0.0.0/0 scram-sha-256 clientcert=verify-full # mTLS and server login for all connections
+      - hostnossl all all 0.0.0.0/0 reject
+
+  storage:
+    size: {{ .Values.storage.database.cnpg.storege.size }}
+    storageClass: {{ .Values.storage.database.cnpg.storege.storageClass }}
+
+  certificates:
+    serverCASecret:   {{ include "sbombastic.fullname" . }}-cnpg-server-ca-key-pair
+    serverTLSSecret:  {{ include "sbombastic.fullname" . }}-cnpg-server-cert
+    clientCASecret:   {{ include "sbombastic.fullname" . }}-cnpg-client-ca-key-pair
+    replicationTLSSecret: {{ include "sbombastic.fullname" . }}-cnpg-client-cert
+{{- end }}

--- a/charts/sbombastic/templates/storage/deployment.yaml
+++ b/charts/sbombastic/templates/storage/deployment.yaml
@@ -24,6 +24,19 @@ spec:
           image: '{{ template "system_default_registry" . }}{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}'
           securityContext:
             {{ include "sbombastic.securityContext" . | nindent 12 }}
+          env:
+            - name: DATABASE_SSLMODE
+              {{- if .Values.storage.database.enableBuiltInCnpg }}
+              value: {{ .Values.storage.database.cnpg.tls.sslmode }}
+              {{- else }}
+              value: {{ .Values.storage.database.externalPostgres.tls.sslmode }}
+              {{- end }}
+            - name: DATABASE_TLS_MODE
+               {{- if .Values.storage.database.enableBuiltInCnpg }}
+              value: mTLS
+              {{- else }}
+              value: {{ .Values.storage.database.externalPostgres.tls.mode }}
+              {{- end }}
           args:
             - --cert-dir=/certs
           {{- if .Values.storage.logLevel }}
@@ -35,9 +48,61 @@ spec:
               mountPath: /data/sqlite/
             - name: cert-volume
               mountPath: /certs
+            - name: database-credential-volume
+              mountPath: /database/credential
+            {{- if .Values.storage.database.enableBuiltInCnpg }}
+            - name: database-client-cert-volume
+              mountPath: /database/client-cert
+            - name: database-server-ca-volume
+              mountPath: /database/server-ca
+            {{- else if eq .Values.storage.database.externalPostgres.tls.mode "mTLS" }}
+            - name: database-client-cert-volume
+              mountPath: /database/client-cert
+            - name: database-server-ca-volume
+              mountPath: /database/server-ca
+            {{- else if eq .Values.storage.database.externalPostgres.tls.mode "TLS" }}
+            - name: database-server-ca-volume
+              mountPath: /database/server-ca
+            {{- end }}
       volumes:
         - name: sqlite-pvc
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.storageData.existingClaim }}{{ .Values.persistence.storageData.existingClaim }}{{- else }}{{ template "sbombastic.fullname" . }}-storage-data{{- end }}
         - name: cert-volume
           emptyDir: {}
+        {{- if .Values.storage.database.enableBuiltInCnpg }}
+        - name: database-credential-volume
+          secret:
+            secretName: {{ .Values.storage.database.cnpg.credential }}
+            defaultMode: 0444
+        {{- else }}
+        - name: database-credential-volume
+          secret:
+            secretName: {{ .Values.storage.database.externalPostgres.credential }}
+            defaultMode: 0444
+        {{- end }}
+
+        {{- if .Values.storage.database.enableBuiltInCnpg }}
+        - name: database-client-cert-volume
+          secret:
+            secretName: {{ .Values.storage.database.cnpg.tls.clientCert }}
+            defaultMode: 0444
+        - name: database-server-ca-volume
+          secret:
+            secretName: {{ .Values.storage.database.cnpg.tls.serverCA }}
+            defaultMode: 0444
+        {{- else if eq .Values.storage.database.externalPostgres.tls.mode "mTLS" }}
+        - name: database-client-cert-volume
+          secret:
+            secretName: {{ .Values.storage.database.externalPostgres.tls.clientCert }}
+            defaultMode: 0444
+        - name: database-server-ca-volume
+          secret:
+            secretName: {{ .Values.storage.database.externalPostgres.tls.serverCA }}
+            defaultMode: 0444
+        {{- else if eq .Values.storage.database.externalPostgres.tls.mode "TLS" }}
+        - name: database-server-ca-volume
+          secret:
+            secretName: {{ .Values.storage.database.externalPostgres.tls.serverCA }}
+            defaultMode: 0444
+        {{- end }}

--- a/charts/sbombastic/tests/storage/deployment_test.yaml
+++ b/charts/sbombastic/tests/storage/deployment_test.yaml
@@ -44,3 +44,171 @@ tests:
       - equal:
           path: "spec.template.spec.volumes[0].persistentVolumeClaim.claimName"
           value: "existing-claim"
+
+  - it: "Ensure the cnpg engine should mount the correct database credential secret"
+    set:
+      storage:
+        database:
+          engine: cnpg
+          cnpg:
+            credential: test-pg-server-app
+            tls:
+              sslmode: verify-cnpg-full
+              clientCert: test-client-cert
+              serverCA: test-server-ca-key-pair
+    asserts:
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-credential-volume"
+            secret:
+              secretName: test-pg-server-app
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-client-cert-volume"
+            secret:
+              secretName: test-client-cert
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-server-ca-volume"
+            secret:
+              secretName: test-server-ca-key-pair
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.containers[0].env"
+          content:
+            name: "DATABASE_SSLMODE"
+            value: "verify-cnpg-full"
+
+  - it: "Ensure the external postgres should mount the correct database credential secret"
+    set:
+      storage:
+        database:
+          enableBuiltInCnpg: false
+          externalPostgres:
+            credential: test-external-db-auth
+            tls:
+              mode: mTLS
+              clientCert: test-external-client-cert
+              serverCA: test-external-server-ca-key-pair
+              sslmode: verify-external-full
+    asserts:
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-credential-volume"
+            secret:
+              secretName: test-external-db-auth
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-client-cert-volume"
+            secret:
+              secretName: test-external-client-cert
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-server-ca-volume"
+            secret:
+              secretName: test-external-server-ca-key-pair
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.containers[0].env"
+          content:
+            name: "DATABASE_SSLMODE"
+            value: "verify-external-full"
+      - contains:
+          path: "spec.template.spec.containers[0].env"
+          content:
+            name: "DATABASE_TLS_MODE"
+            value: "mTLS"
+
+  - it: "Ensure the external postgres should mount the correct database credential secret when TLS is enabled"
+    set:
+      storage:
+        database:
+          enableBuiltInCnpg: false
+          externalPostgres:
+            credential: test-external-db-auth
+            tls:
+              mode: TLS
+              clientCert: test-external-client-cert
+              serverCA: test-external-server-ca-key-pair
+              sslmode: verify-external-full
+    asserts:
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-credential-volume"
+            secret:
+              secretName: test-external-db-auth
+              defaultMode: 0444
+      - notContains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-client-cert-volume"
+            secret:
+              secretName: test-external-client-cert
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-server-ca-volume"
+            secret:
+              secretName: test-external-server-ca-key-pair
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.containers[0].env"
+          content:
+            name: "DATABASE_SSLMODE"
+            value: "verify-external-full"
+      - contains:
+          path: "spec.template.spec.containers[0].env"
+          content:
+            name: "DATABASE_TLS_MODE"
+            value: "TLS"
+
+  - it: "Ensure the external postgres should mount the correct database credential secret when no TLS is enabled"
+    set:
+      storage:
+        database:
+          enableBuiltInCnpg: false
+          externalPostgres:
+            credential: test-external-db-auth
+            tls:
+              mode: disable
+              serverCA: test-external-server-ca-key-pair
+              clientCert: test-external-client-cert
+    asserts:
+      - contains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-credential-volume"
+            secret:
+              secretName: test-external-db-auth
+              defaultMode: 0444
+      - notContains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-client-cert-volume"
+            secret:
+              secretName: test-external-client-cert
+              defaultMode: 0444
+      - notContains:
+          path: "spec.template.spec.volumes"
+          content:
+            name: "database-server-ca-volume"
+            secret:
+              secretName: test-external-server-ca-key-pair
+              defaultMode: 0444
+      - contains:
+          path: "spec.template.spec.containers[0].env"
+          content:
+            name: "DATABASE_TLS_MODE"
+            value: "disable"

--- a/charts/sbombastic/values.yaml
+++ b/charts/sbombastic/values.yaml
@@ -23,6 +23,49 @@ storage:
   replicas: 1
   # logLevel: "debug" //TODO: uncomment this, when the log parser in storage is implemented
 
+  # NOTE: This section configure the storage backend for the sbombastic.
+  # User can choose to between cloudnative PG (default) or an external PostgreSQL instance.
+  database:
+    enableBuiltInCnpg: true
+    # === Default Option : We provision the cluster ===
+    # NOTE: This section is used to enable cnpg by default, it will create postgres server pod for user.
+    cnpg:
+      credential: sbombastic-pg-server-app
+      tls:
+        sslmode: verify-full
+        clientCert: sbombastic-cnpg-client-cert
+        serverCA: sbombastic-cnpg-server-ca-key-pair
+
+      fullnameOverride: sbombastic-pg-server
+      cluster:
+        instances: 1
+        initdb:
+          database: sbombastic
+          owner: sbombastic
+
+      storege:
+        size: 1Gi
+        # storageClass: standard # Default storage class, can be overridden by the user
+
+    # === Option 2: User-provided PostgreSQL instance ===
+    # Enable this only if you're using an existing external PostgreSQL database.
+    externalPostgres:
+      credential: external-db-auth
+      # NOTE: The credential secret is used to store the credentials for the external PostgreSQL instance.
+      # It is expected to have the following fields:
+      # - host: PostgreSQL server URL
+      # - port: PostgreSQL server port
+      # - database: name of the database
+      # - username: username for the database
+      # - password: password for the database
+
+      # Optional TLS/mTLS settings
+      tls:
+        mode: mTLS                   # mTLS, TLS, disable
+        sslmode: verify-full         # Required: e.g., "disable", "require", "verify-ca", "verify-full"
+        serverCA: "external-db-server-ca"   # Optional: Secret with server CA cert (tls.crt), required for mTLS / TLS
+        clientCert: "external-db-client-cert" # Optional: Required for mTLS (tls.crt + tls.key), required for mTLS
+
 worker:
   image:
     repository: rancher-sandbox/sbombastic/worker
@@ -31,6 +74,8 @@ worker:
   replicas: 3
   logLevel: "info"
 
+
+# TODO: Remove this section when the cnpg integration is done
 persistence:
   enabled: true
 
@@ -40,11 +85,15 @@ persistence:
     subPath:
     annotations: {}
     labels: {}
-    # storageClass: ""
+    # storageClass: "standard" # TODO: change this to the storage class you want to use
     ## If defined, PVC must be created manually before volume will be bound
     # existingClaim:
     accessMode: ReadWriteOnce
     size: 1Gi
+
+# NOTE: This section is used to harden the deployment of the sbombastic components, default to true
+security:
+  harden_deployment: true
 
 # NOTE: This section is used to configure the NATS server and its components
 # deployed by the NATS chart dependency.

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -66,6 +66,28 @@ func TestMain(m *testing.M) {
 				return ctx, fmt.Errorf("failed to install cert-manager: %w", err)
 			}
 
+			// Add the CloudNativePG Helm repository for cnpg
+			err = manager.RunRepo(helm.WithArgs(
+				"add",
+				"cnpg",
+				"https://cloudnative-pg.github.io/charts",
+				"--force-update"),
+			)
+			if err != nil {
+				return ctx, fmt.Errorf("failed to add cnpg helm repo: %w", err)
+			}
+
+			// Install cloudnative-pg
+			err = manager.RunInstall(
+				helm.WithName("cnpg"),
+				helm.WithChart("cnpg/cloudnative-pg"),
+				helm.WithWait(),
+				helm.WithArgs("--set", "config.clusterWide=false"),
+				helm.WithNamespace(namespace),
+				helm.WithTimeout("3m"))
+			if err != nil {
+				return ctx, fmt.Errorf("failed to install cnpg: %w", err)
+			}
 			return ctx, nil
 		},
 	)


### PR DESCRIPTION
## Description
- Fix https://github.com/rancher-sandbox/sbombastic/issues/287
- This update streamlines the installation and development workflow for CloudNativePG (CNPG) by combining the operator, CRDs, and cluster resources into a single, secure Helm deployment.

### Key changes

- **Install CNPG with one command**  
  - Add the **CloudNativePG operator** as a chart dependency to register CRDs and run control loops.  
  - Include a **Cluster manifest** in `templates/cnpg/` that creates PostgreSQL pods after the operator is ready.

- **Enable mTLS with cert-manager**  
  - Embed cert-manager resources into your Helm chart.  
  - Configure server certificates so all CNPG connections are encrypted by default, inspired by [cnpg doc](https://cloudnative-pg.io/documentation/current/samples/cluster-example-cert-manager.yaml)

- **Add security section in value**
  - In Tilt dev, if we enable readonly filesystem, we may not utilize the live update from tilt, so I create one option for this.
  
- **Refactor the Tiltfile**  
  - Replace `helm()` + `k8s_yaml()` with `helm_resource()` to wait for the operator to be fully healthy before applying the Cluster manifest.  
  - Add `resource_deps` flags to guarantee correct ordering.

- **External database support**  
  - User is able to use the external postgres in sbombastic, as long as they provide credentials and TLS data (optional).

## Test
- [ ] tilt up works fine, and change the dependency file will reflect on the log

