### PR TITLE
chore: bump helm version and ensure release is latest

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -85,7 +85,7 @@ jobs:
           # Upload the charts if the .cr-release-packages directory is not empty
           if [ "$(ls ${PACKAGE_PATH})" ]; then
             # Upload the chart to the GitHub release
-            cr upload --config ${CONFIG_FILE} -o ${OWNER} -r ${REPO} -c "$(git rev-parse HEAD)" --skip-existing  --make-release-latest=false --token ${CR_TOKEN} --push
+            cr upload --config ${CONFIG_FILE} -o ${OWNER} -r ${REPO} -c "$(git rev-parse HEAD)" --skip-existing  --make-release-latest=true --token ${CR_TOKEN} --push
             echo "Charts released!"
 
             # Reindex the repository

--- a/charts/sbombastic/Chart.yaml
+++ b/charts/sbombastic/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-alpha2
+version: 0.1.0-alpha3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Description

- Bump the chart version for testing the helm chart release pipeline.

## Test example
<img width="269" height="150" alt="Screenshot 2025-07-11 at 11 22 14 PM" src="https://github.com/user-attachments/assets/3c1edbb1-a4fd-4741-8528-c37688ba46f7" />
