### PR TITLE
fix: Tiltfile 

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -51,6 +51,7 @@ helm_resource(
 load("ext://namespace", "namespace_create")
 namespace_create("sbombastic")
 
+registry = settings.get("registry")
 controller_image = settings.get("controller").get("image")
 storage_image = settings.get("storage").get("image")
 worker_image = settings.get("worker").get("image")
@@ -60,6 +61,7 @@ yaml = helm(
     name="sbombastic",
     namespace="sbombastic",
     set=[
+        "global.cattle.systemDefaultRegistry=" + registry,
         "controller.image.repository=" + controller_image,
         "storage.image.repository=" + storage_image,
         "worker.image.repository=" + worker_image,
@@ -89,7 +91,7 @@ dockerfile = "./hack/Dockerfile.controller.tilt"
 
 load("ext://restart_process", "docker_build_with_restart")
 docker_build_with_restart(
-    controller_image,
+    registry + "/" + controller_image,
     ".",
     dockerfile=dockerfile,
     entrypoint=entrypoint,
@@ -123,7 +125,7 @@ dockerfile = "./hack/Dockerfile.storage.tilt"
 
 load("ext://restart_process", "docker_build_with_restart")
 docker_build_with_restart(
-    storage_image,
+    registry + "/" + storage_image,
     ".",
     dockerfile=dockerfile,
     entrypoint=entrypoint,
@@ -157,7 +159,7 @@ dockerfile = "./hack/Dockerfile.worker.tilt"
 
 load("ext://restart_process", "docker_build_with_restart")
 docker_build_with_restart(
-    worker_image,
+    registry + "/" + worker_image,
     ".",
     dockerfile=dockerfile,
     entrypoint=entrypoint,

--- a/Tiltfile
+++ b/Tiltfile
@@ -27,7 +27,7 @@ local_resource(
 )
 
 load("ext://helm_resource", "helm_resource", "helm_repo")
-helm_repo("jetstack-repo", "https://charts.jetstack.io")
+helm_repo("jetstack", "https://charts.jetstack.io")
 helm_resource(
     "cert-manager",
     "jetstack/cert-manager",
@@ -40,7 +40,7 @@ helm_resource(
         "installCRDs=false",
     ],
     resource_deps=[
-        "jetstack-repo",
+        "jetstack",
         "cert-manager-crds",
     ],
 )

--- a/tilt-settings.yaml.example
+++ b/tilt-settings.yaml.example
@@ -1,6 +1,7 @@
+registry: ghcr.io
 storage: 
-    image: <your-repository>/storage
+    image: <username>/sbombastic/storage
 controller: 
-    image: <your-repository>/controller
+    image: <username>/sbombastic/controller
 worker: 
-    image: <your-repository>/worker
+    image: <username>/sbombastic/worker


### PR DESCRIPTION
## Description

This PR:
- Corrects the Helm repository name for cert-manager in the Tiltfile.
- Introduces a registry setting to support the change introduced in #310, where image values no longer include the registry prefix and must be specified separately.