### PR TITLE
feat: add ScanJob webhook

### DIFF
--- a/charts/sbombastic/templates/controller/cert-manager.yaml
+++ b/charts/sbombastic/templates/controller/cert-manager.yaml
@@ -1,10 +1,39 @@
 apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-controller-webhook-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-controller-webhook-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+spec:
+  secretName: {{ include "sbombastic.fullname" . }}-controller-webhook-tls
+  dnsNames:
+    - {{ include "sbombastic.fullname" . }}-controller-webhook.{{ .Release.Namespace }}.svc
+    - {{ include "sbombastic.fullname" . }}-controller-webhook.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "sbombastic.fullname" . }}-controller-webhook-issuer
+---
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "sbombastic.fullname" . }}-nats-controller-client-tls
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
 spec:
   secretName: {{ include "sbombastic.fullname" . }}-nats-controller-client-tls
   dnsNames:
@@ -15,3 +44,4 @@ spec:
     name: {{ include "sbombastic.fullname" . }}-nats-ca
     kind: Issuer
     group: cert-manager.io
+

--- a/charts/sbombastic/templates/controller/deployment.yaml
+++ b/charts/sbombastic/templates/controller/deployment.yaml
@@ -54,10 +54,16 @@ spec:
               cpu: 10m
               memory: 64Mi
           volumeMounts:
+            - mountPath: "/tmp/k8s-webhook-server/serving-certs"
+              name: webhook-tls
+              readOnly: true
             - mountPath: "/nats/tls"
               name: nats-tls
               readOnly: true
       volumes:
+        - name: webhook-tls
+          secret:
+            secretName: {{ include "sbombastic.fullname" . }}-controller-webhook-tls
         - name: nats-tls
           secret:
             secretName: {{ include "sbombastic.fullname" . }}-nats-controller-client-tls

--- a/charts/sbombastic/templates/controller/service.yaml
+++ b/charts/sbombastic/templates/controller/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-controller-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    {{- include "sbombastic.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: controller

--- a/charts/sbombastic/templates/controller/webhooks.yaml
+++ b/charts/sbombastic/templates/controller/webhooks.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "sbombastic.fullname" . }}-controller-webhook-tls
+  name: {{ include "sbombastic.fullname" . }}-controller-webhook
+  labels:
+    {{ include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: {{ include "sbombastic.fullname" . }}-controller-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /validate-sbombastic-rancher-io-v1alpha1-scanjob
+  failurePolicy: Fail
+  name: vscanjob.sbombastic.rancher.io
+  rules:
+  - apiGroups:
+    - sbombastic.rancher.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - scanjobs
+  sideEffects: None

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/rancher/sbombastic/internal/cmdutil"
 	"github.com/rancher/sbombastic/internal/controller"
 	"github.com/rancher/sbombastic/internal/messaging"
+	webhookv1alpha1 "github.com/rancher/sbombastic/internal/webhook/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -218,6 +219,11 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VulnerabilityReport")
+		os.Exit(1)
+	}
+
+	if err = webhookv1alpha1.SetupScanJobWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "ScanJob")
 		os.Exit(1)
 	}
 

--- a/internal/webhook/v1alpha1/scanjob_webhook.go
+++ b/internal/webhook/v1alpha1/scanjob_webhook.go
@@ -1,0 +1,119 @@
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/go-logr/logr"
+	sbombasticv1alpha1 "github.com/rancher/sbombastic/api/v1alpha1"
+)
+
+func SetupScanJobWebhookWithManager(mgr ctrl.Manager) error {
+	err := ctrl.NewWebhookManagedBy(mgr).
+		For(&sbombasticv1alpha1.ScanJob{}).
+		WithValidator(&ScanJobCustomValidator{
+			client: mgr.GetClient(),
+			logger: mgr.GetLogger().WithName("scanjob_webhook"),
+		}).
+		Complete()
+	if err != nil {
+		return fmt.Errorf("failed to setup ScanJob webhook: %w", err)
+	}
+
+	return nil
+}
+
+type ScanJobCustomValidator struct {
+	client client.Client
+	logger logr.Logger
+}
+
+var _ webhook.CustomValidator = &ScanJobCustomValidator{}
+
+func (v *ScanJobCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	scanJob, ok := obj.(*sbombasticv1alpha1.ScanJob)
+	if !ok {
+		return nil, fmt.Errorf("expected a ScanJob object but got %T", obj)
+	}
+	v.logger.Info("Validation for ScanJob upon creation", "name", scanJob.GetName())
+
+	var allErrs field.ErrorList
+	fieldPath := field.NewPath("metadata").Child("name")
+	// ScanJob names are limited to 63 characters because they are used as labels to identify VulnerabilityReports updated by the ScanJob.
+	if len(scanJob.Name) > validation.LabelValueMaxLength {
+		allErrs = append(allErrs, field.TooLong(fieldPath, scanJob.Name, validation.LabelValueMaxLength))
+	}
+
+	scanJobList := &sbombasticv1alpha1.ScanJobList{}
+	if err := v.client.List(ctx, scanJobList, client.InNamespace(scanJob.GetNamespace())); err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("listing ScanJobs: %w", err))
+	}
+
+	for _, existingScanJob := range scanJobList.Items {
+		// Check if the a ScanJob with the same registry is already running
+		if existingScanJob.Spec.Registry == scanJob.Spec.Registry && (!existingScanJob.IsComplete() && !existingScanJob.IsFailed()) {
+			fieldPath := field.NewPath("spec").Child("registry")
+			allErrs = append(allErrs, field.Forbidden(fieldPath, fmt.Sprintf("a ScanJob for the registry %q is already running", scanJob.Spec.Registry)))
+
+			break
+		}
+	}
+
+	if len(allErrs) > 0 {
+		return nil, apierrors.NewInvalid(
+			sbombasticv1alpha1.GroupVersion.WithKind("ScanJob").GroupKind(),
+			scanJob.Name,
+			allErrs,
+		)
+	}
+
+	return nil, nil
+}
+
+func (v *ScanJobCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldJob, ok := oldObj.(*sbombasticv1alpha1.ScanJob)
+	if !ok {
+		return nil, fmt.Errorf("expected oldObj to be a ScanJob but got %T", oldObj)
+	}
+	newJob, ok := newObj.(*sbombasticv1alpha1.ScanJob)
+	if !ok {
+		return nil, fmt.Errorf("expected newObj to be a ScanJob but got %T", newObj)
+	}
+
+	v.logger.Info("Validation for ScanJob upon update", "name", newJob.GetName())
+
+	if oldJob.Spec.Registry != newJob.Spec.Registry {
+		fieldErr := field.Invalid(
+			field.NewPath("spec").Child("registry"),
+			newJob.Spec.Registry,
+			"field is immutable")
+
+		return nil, apierrors.NewInvalid(
+			sbombasticv1alpha1.GroupVersion.WithKind("ScanJob").GroupKind(),
+			newJob.Name,
+			field.ErrorList{fieldErr},
+		)
+	}
+
+	return nil, nil
+}
+
+func (v *ScanJobCustomValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	scanJob, ok := obj.(*sbombasticv1alpha1.ScanJob)
+	if !ok {
+		return nil, fmt.Errorf("expected a ScanJob object but got %T", obj)
+	}
+	v.logger.Info("Validation for ScanJob upon deletion", "name", scanJob.GetName())
+
+	return nil, nil
+}

--- a/internal/webhook/v1alpha1/scanjob_webhook_test.go
+++ b/internal/webhook/v1alpha1/scanjob_webhook_test.go
@@ -1,0 +1,230 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sbombasticv1alpha1 "github.com/rancher/sbombastic/api/v1alpha1"
+)
+
+func TestScanJobCustomValidator_ValidateCreate(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingScanJob *sbombasticv1alpha1.ScanJob
+		scanJob         *sbombasticv1alpha1.ScanJob
+		expectedError   string
+		expectedField   string
+	}{
+		{
+			name:            "should admit creation when no existing jobs with same registry",
+			existingScanJob: nil,
+			scanJob: &sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scan-job",
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: "registry.example.com",
+				},
+			},
+		},
+		{
+			name: "should deny creation when existing job with same registry is pending",
+			existingScanJob: func() *sbombasticv1alpha1.ScanJob {
+				job := &sbombasticv1alpha1.ScanJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-job",
+						Namespace: "default",
+					},
+					Spec: sbombasticv1alpha1.ScanJobSpec{
+						Registry: "registry.example.com",
+					},
+				}
+				job.InitializeConditions()
+				return job
+			}(),
+			scanJob: &sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scan-job",
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: "registry.example.com",
+				},
+			},
+			expectedField: "spec.registry",
+			expectedError: "is already running",
+		},
+		{
+			name: "should deny creation when existing job with same registry is in progress",
+			existingScanJob: func() *sbombasticv1alpha1.ScanJob {
+				job := &sbombasticv1alpha1.ScanJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-job",
+						Namespace: "default",
+					},
+					Spec: sbombasticv1alpha1.ScanJobSpec{
+						Registry: "registry.example.com",
+					},
+				}
+				job.InitializeConditions()
+				job.MarkInProgress(sbombasticv1alpha1.ReasonImageScanInProgress, "Image scan in progress")
+				return job
+			}(),
+			scanJob: &sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scan-job",
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: "registry.example.com",
+				},
+			},
+			expectedField: "spec.registry",
+			expectedError: "is already running",
+		},
+		{
+			name: "should admit creation when existing job with same registry is completed",
+			existingScanJob: func() *sbombasticv1alpha1.ScanJob {
+				job := &sbombasticv1alpha1.ScanJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-job",
+						Namespace: "default",
+					},
+					Spec: sbombasticv1alpha1.ScanJobSpec{
+						Registry: "registry.example.com",
+					},
+				}
+				job.InitializeConditions()
+				job.MarkComplete(sbombasticv1alpha1.ReasonAllImagesScanned, "Done")
+				return job
+			}(),
+			scanJob: &sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scan-job",
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: "registry.example.com",
+				},
+			},
+		},
+		{
+			name: "should admit creation when existing job with same registry failed",
+			existingScanJob: func() *sbombasticv1alpha1.ScanJob {
+				job := &sbombasticv1alpha1.ScanJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-job",
+						Namespace: "default",
+					},
+					Spec: sbombasticv1alpha1.ScanJobSpec{
+						Registry: "registry.example.com",
+					},
+				}
+				job.InitializeConditions()
+				job.MarkFailed(sbombasticv1alpha1.ReasonInternalError, "Failed")
+				return job
+			}(),
+			scanJob: &sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scan-job",
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: "registry.example.com",
+				},
+			},
+		},
+		{
+			name: "should deny creation when name exceeds max length",
+			scanJob: &sbombasticv1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "this-name-is-way-too-long-and-exceeds-the-sixty-three-character-limit-that-is-set-for-kubernetes-labels",
+					Namespace: "default",
+				},
+				Spec: sbombasticv1alpha1.ScanJobSpec{
+					Registry: "registry.example.com",
+				},
+			},
+			expectedField: "metadata.name",
+			expectedError: "Too long: may not be more than 63 bytes",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, sbombasticv1alpha1.AddToScheme(scheme))
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			validator := ScanJobCustomValidator{client: client}
+
+			if test.existingScanJob != nil {
+				require.NoError(t, client.Create(t.Context(), test.existingScanJob))
+			}
+
+			warnings, err := validator.ValidateCreate(t.Context(), test.scanJob)
+
+			if test.expectedError != "" {
+				require.Error(t, err)
+				statusErr, ok := err.(interface{ Status() metav1.Status })
+				require.True(t, ok)
+				details := statusErr.Status().Details
+				require.NotNil(t, details)
+				require.Len(t, details.Causes, 1)
+				assert.Equal(t, test.expectedField, details.Causes[0].Field)
+				assert.Contains(t, details.Causes[0].Message, test.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Empty(t, warnings)
+		})
+	}
+}
+
+func TestScanJobCustomValidator_ValidateUpdate(t *testing.T) {
+	oldObj := &sbombasticv1alpha1.ScanJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-scan-job",
+			Namespace: "default",
+		},
+		Spec: sbombasticv1alpha1.ScanJobSpec{
+			Registry: "registry.example.com",
+		},
+	}
+
+	newObj := &sbombasticv1alpha1.ScanJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-scan-job",
+			Namespace: "default",
+		},
+		Spec: sbombasticv1alpha1.ScanJobSpec{
+			Registry: "new-registry.example.com",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, sbombasticv1alpha1.AddToScheme(scheme))
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	validator := ScanJobCustomValidator{client: client}
+
+	warnings, err := validator.ValidateUpdate(t.Context(), oldObj, newObj)
+
+	require.Error(t, err)
+	statusErr, ok := err.(interface{ Status() metav1.Status })
+	require.True(t, ok)
+	details := statusErr.Status().Details
+	require.NotNil(t, details)
+	require.Len(t, details.Causes, 1)
+	assert.Equal(t, "spec.registry", details.Causes[0].Field)
+	assert.Contains(t, details.Causes[0].Message, "immutable")
+
+	assert.Empty(t, warnings)
+}


### PR DESCRIPTION
## Description
This PR adds a validating webhook for ScanJob validation with the following rules:

**On creation:**
- Block ScanJobs with names longer than 63 characters (k8s label max length). We use ScanJob names as labels to identify the vulnerability reports they create/update.
- Block creation if another ScanJob for the same registry is already running

**On update:**
- Make the registry field immutable

It also sets up webhook TLS in the controller and creates the validating webhook configuration.

Fixes #268 
Related to #241 