### PR TITLE
build(deps): bump cert-manager to 1.18.2

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -18,7 +18,7 @@ k8s_resource(
 # Note: We are not using the tilt cert-manager extension, since it creates a namespace to test cert-manager,
 # which takes a long time to delete when running `tilt down`.
 # We Install the cert-manager CRDs separately, so we are sure they will be avalable before the sbombastic Helm chart is installed.
-cert_manager_version = "v1.17.2"
+cert_manager_version = "v1.18.2"
 local_resource(
     "cert-manager-crds",
     cmd="kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/{}/cert-manager.crds.yaml".format(

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -21,7 +21,7 @@ var (
 	controllerImage      = "ghcr.io/rancher-sandbox/sbombastic/controller:latest"
 	storageImage         = "ghcr.io/rancher-sandbox/sbombastic/storage:latest"
 	certManagerNamespace = "cert-manager"
-	certManagerVersion   = "v1.17.2"
+	certManagerVersion   = "v1.18.2"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Description
Bumps to latest cert-manager version in the Tiltfile and e2e tests