### PR TITLE
chore: constants cleanup

### DIFF
--- a/api/labels.go
+++ b/api/labels.go
@@ -1,9 +1,10 @@
 package api
 
+// Common labels used across the application
+
 const (
 	LabelManagedByKey   = "app.kubernetes.io/managed-by"
 	LabelManagedByValue = "sbombastic"
 	LabelPartOfKey      = "app.kubernetes.io/part-of"
 	LabelPartOfValue    = "sbombastic"
-	LabelScanJobUIDKey  = "sbombastic.rancher.io/scanjob-uid"
 )

--- a/api/v1alpha1/scanjob_types.go
+++ b/api/v1alpha1/scanjob_types.go
@@ -7,6 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const LabelScanJobUIDKey = "sbombastic.rancher.io/scanjob-uid"
+
 const (
 	// IndexScanJobSpecRegistry is the field index for the registry of a ScanJob.
 	IndexScanJobSpecRegistry = "spec.registry"
@@ -16,12 +18,12 @@ const (
 
 // RegistryAnnotation stores a snapshot of the Registry targeted by the ScanJob.
 const (
-	// RegistryAnnotation stores a snapshot of the Registry targeted by the ScanJob.
-	RegistryAnnotation = "sbombastic.rancher.io/registry"
-	// CreationTimestampAnnotation is used to store the creation timestamp of the ScanJob.
-	CreationTimestampAnnotation = "sbombastic.rancher.io/creation-timestamp"
-	// TriggerAnnotation is used to identify the source of the ScanJob trigger.
-	TriggerAnnotation = "sbombastic.rancher.io/trigger"
+	// AnnotationScanJobRegistryKey stores a snapshot of the Registry targeted by the ScanJob.
+	AnnotationScanJobRegistryKey = "sbombastic.rancher.io/registry"
+	// AnnotationScanJobCreationTimestampKey is used to store the creation timestamp of the ScanJob.
+	AnnotationScanJobCreationTimestampKey = "sbombastic.rancher.io/creation-timestamp"
+	// AnnotationScanJobTriggerKey is used to identify the source of the ScanJob trigger.
+	AnnotationScanJobTriggerKey = "sbombastic.rancher.io/trigger"
 )
 
 // ScanJobSpec defines the desired state of ScanJob.
@@ -100,7 +102,7 @@ type ScanJob struct {
 // If the annotation is missing or malformed, it falls back to the Kubernetes object's
 // standard metadata.CreationTimestamp.
 func (s *ScanJob) GetCreationTimestampFromAnnotation() time.Time {
-	if timestampStr, ok := s.Annotations[CreationTimestampAnnotation]; ok {
+	if timestampStr, ok := s.Annotations[AnnotationScanJobCreationTimestampKey]; ok {
 		if timestamp, err := time.Parse(time.RFC3339Nano, timestampStr); err == nil {
 			return timestamp
 		}

--- a/internal/controller/registry_controller.go
+++ b/internal/controller/registry_controller.go
@@ -45,12 +45,14 @@ func (r *RegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(1).
 			Info("Deleting Images that are not in the current list of repositories", "name", registry.Name, "namespace", registry.Namespace, "repositories", registry.Spec.Repositories)
 
-		fieldSelector := client.MatchingFields{
-			storagev1alpha1.IndexImageMetadataRegistry: registry.Name,
+		images := &storagev1alpha1.ImageList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(req.Namespace),
+			client.MatchingFields{
+				storagev1alpha1.IndexImageMetadataRegistry: registry.Name,
+			},
 		}
-
-		var images storagev1alpha1.ImageList
-		if err := r.List(ctx, &images, client.InNamespace(req.Namespace), fieldSelector); err != nil {
+		if err := r.List(ctx, images, listOpts...); err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to list Images: %w", err)
 		}
 

--- a/internal/controller/registry_scan_runner.go
+++ b/internal/controller/registry_scan_runner.go
@@ -149,7 +149,7 @@ func (r *RegistryScanRunner) createScanJob(ctx context.Context, registry *v1alph
 			GenerateName: fmt.Sprintf("%s-", registry.Name),
 			Namespace:    registry.Namespace,
 			Annotations: map[string]string{
-				v1alpha1.TriggerAnnotation: "runner",
+				v1alpha1.AnnotationScanJobTriggerKey: "runner",
 			},
 		},
 		Spec: v1alpha1.ScanJobSpec{

--- a/internal/controller/registry_scan_runner.go
+++ b/internal/controller/registry_scan_runner.go
@@ -121,9 +121,8 @@ func (r *RegistryScanRunner) getLastScanJob(ctx context.Context, registry *v1alp
 
 	listOpts := []client.ListOption{
 		client.InNamespace(registry.Namespace),
-		client.MatchingFields{"spec.registry": registry.Name},
+		client.MatchingFields{v1alpha1.IndexScanJobSpecRegistry: registry.Name},
 	}
-
 	if err := r.List(ctx, &scanJobs, listOpts...); err != nil {
 		return nil, fmt.Errorf("failed to list scan jobs: %w", err)
 	}

--- a/internal/controller/registry_scan_runner_test.go
+++ b/internal/controller/registry_scan_runner_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rancher/sbombastic/api/v1alpha1"
@@ -48,7 +47,7 @@ var _ = Describe("RegistryScanRunner", func() {
 				scanJobs := &v1alpha1.ScanJobList{}
 				Expect(k8sClient.List(ctx, scanJobs,
 					client.InNamespace("default"),
-					client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector("spec.registry", registry.Name)},
+					client.MatchingFields{v1alpha1.IndexScanJobSpecRegistry: registry.Name},
 				)).To(Succeed())
 				Expect(scanJobs.Items).To(BeEmpty())
 
@@ -59,7 +58,7 @@ var _ = Describe("RegistryScanRunner", func() {
 				By("Verifying a new scan job was created")
 				Expect(k8sClient.List(ctx, scanJobs,
 					client.InNamespace("default"),
-					client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector("spec.registry", registry.Name)},
+					client.MatchingFields{v1alpha1.IndexScanJobSpecRegistry: registry.Name},
 				)).To(Succeed())
 				Expect(scanJobs.Items).To(HaveLen(1))
 
@@ -89,7 +88,7 @@ var _ = Describe("RegistryScanRunner", func() {
 				scanJobs := &v1alpha1.ScanJobList{}
 				Expect(k8sClient.List(ctx, scanJobs,
 					client.InNamespace("default"),
-					client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector("spec.registry", registry.Name)},
+					client.MatchingFields{v1alpha1.IndexScanJobSpecRegistry: registry.Name},
 				)).To(Succeed())
 				Expect(scanJobs.Items).To(HaveLen(1))
 			})
@@ -118,7 +117,7 @@ var _ = Describe("RegistryScanRunner", func() {
 				scanJobs := &v1alpha1.ScanJobList{}
 				Expect(k8sClient.List(ctx, scanJobs,
 					client.InNamespace("default"),
-					client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector("spec.registry", registry.Name)},
+					client.MatchingFields{v1alpha1.IndexScanJobSpecRegistry: registry.Name},
 				)).To(Succeed())
 				Expect(scanJobs.Items).To(HaveLen(2))
 			})
@@ -148,7 +147,7 @@ var _ = Describe("RegistryScanRunner", func() {
 				scanJobs := &v1alpha1.ScanJobList{}
 				Expect(k8sClient.List(ctx, scanJobs,
 					client.InNamespace("default"),
-					client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector("spec.registry", registry.Name)},
+					client.MatchingFields{v1alpha1.IndexScanJobSpecRegistry: registry.Name},
 				)).To(Succeed())
 				Expect(scanJobs.Items).To(HaveLen(1))
 			})
@@ -178,7 +177,7 @@ var _ = Describe("RegistryScanRunner", func() {
 				scanJobs := &v1alpha1.ScanJobList{}
 				Expect(k8sClient.List(ctx, scanJobs,
 					client.InNamespace("default"),
-					client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector("spec.registry", registry.Name)},
+					client.MatchingFields{v1alpha1.IndexScanJobSpecRegistry: registry.Name},
 				)).To(Succeed())
 				Expect(scanJobs.Items).To(BeEmpty())
 			})

--- a/internal/controller/registry_scan_runner_test.go
+++ b/internal/controller/registry_scan_runner_test.go
@@ -64,7 +64,7 @@ var _ = Describe("RegistryScanRunner", func() {
 
 				By("Checking the scan job has correct registry and trigger annotation")
 				Expect(scanJobs.Items[0].Spec.Registry).To(Equal(registry.Name))
-				Expect(scanJobs.Items[0].Annotations).To(HaveKeyWithValue(v1alpha1.TriggerAnnotation, "runner"))
+				Expect(scanJobs.Items[0].Annotations).To(HaveKeyWithValue(v1alpha1.AnnotationScanJobTriggerKey, "runner"))
 			})
 
 			It("Should not create a new job when one is already running", func(ctx context.Context) {

--- a/internal/controller/scanjob_controller.go
+++ b/internal/controller/scanjob_controller.go
@@ -102,7 +102,7 @@ func (r *ScanJobReconciler) reconcileScanJob(ctx context.Context, scanJob *v1alp
 	original := scanJob.DeepCopy()
 
 	scanJob.Annotations = map[string]string{
-		v1alpha1.RegistryAnnotation: string(registryData),
+		v1alpha1.AnnotationScanJobRegistryKey: string(registryData),
 	}
 
 	if err = r.Patch(ctx, scanJob, client.MergeFrom(original)); err != nil {

--- a/internal/controller/scanjob_controller_test.go
+++ b/internal/controller/scanjob_controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("ScanJob Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking that registry data was stored in annotations")
-			registryData, exists := updatedScanJob.Annotations[v1alpha1.RegistryAnnotation]
+			registryData, exists := updatedScanJob.Annotations[v1alpha1.AnnotationScanJobRegistryKey]
 			Expect(exists).To(BeTrue())
 
 			var storedRegistry v1alpha1.Registry
@@ -230,7 +230,7 @@ var _ = Describe("ScanJob Controller", func() {
 						Name:      fmt.Sprintf("old-scanjob-%d", i),
 						Namespace: "default",
 						Annotations: map[string]string{
-							v1alpha1.CreationTimestampAnnotation: creationTimestamp,
+							v1alpha1.AnnotationScanJobCreationTimestampKey: creationTimestamp,
 						},
 					},
 					Spec: v1alpha1.ScanJobSpec{

--- a/internal/controller/vulnerabilityreport_controller.go
+++ b/internal/controller/vulnerabilityreport_controller.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/rancher/sbombastic/api"
 	storagev1alpha1 "github.com/rancher/sbombastic/api/storage/v1alpha1"
 	"github.com/rancher/sbombastic/api/v1alpha1"
 )
@@ -43,7 +42,7 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	scanJobUID, ok := vulnerabilityReport.Labels[api.LabelScanJobUIDKey]
+	scanJobUID, ok := vulnerabilityReport.Labels[v1alpha1.LabelScanJobUIDKey]
 	if !ok {
 		return ctrl.Result{}, fmt.Errorf("scan job UID not found in labels for VulnerabilityReport %s", req.NamespacedName)
 	}
@@ -60,7 +59,7 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 	vulnerabilityReports := &storagev1alpha1.VulnerabilityReportList{}
 	if err := r.List(ctx, vulnerabilityReports,
 		client.InNamespace(req.Namespace),
-		client.MatchingLabels{api.LabelScanJobUIDKey: scanJobUID},
+		client.MatchingLabels{v1alpha1.LabelScanJobUIDKey: scanJobUID},
 	); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list VulnerabilityReports: %w", err)
 	}

--- a/internal/controller/vulnerabilityreport_controller_test.go
+++ b/internal/controller/vulnerabilityreport_controller_test.go
@@ -14,7 +14,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/rancher/sbombastic/api"
 	storagev1alpha1 "github.com/rancher/sbombastic/api/storage/v1alpha1"
 	"github.com/rancher/sbombastic/api/v1alpha1"
 )
@@ -85,7 +84,7 @@ var _ = Describe("VulnerabilityReport Controller", func() {
 						Name:      uuid.New().String(),
 						Namespace: "default",
 						Labels: map[string]string{
-							api.LabelScanJobUIDKey: string(scanJob.UID),
+							v1alpha1.LabelScanJobUIDKey: string(scanJob.UID),
 						},
 					},
 					Spec: storagev1alpha1.VulnerabilityReportSpec{
@@ -124,7 +123,7 @@ var _ = Describe("VulnerabilityReport Controller", func() {
 						Name:      uuid.New().String(),
 						Namespace: "default",
 						Labels: map[string]string{
-							api.LabelScanJobUIDKey: string(scanJob.UID),
+							v1alpha1.LabelScanJobUIDKey: string(scanJob.UID),
 						},
 					},
 					Spec: storagev1alpha1.VulnerabilityReportSpec{
@@ -171,7 +170,7 @@ var _ = Describe("VulnerabilityReport Controller", func() {
 						Name:      uuid.New().String(),
 						Namespace: "default",
 						Labels: map[string]string{
-							api.LabelScanJobUIDKey: "non-existent-uid",
+							v1alpha1.LabelScanJobUIDKey: "non-existent-uid",
 						},
 					},
 					Spec: storagev1alpha1.VulnerabilityReportSpec{

--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -138,7 +138,11 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message []byte) error
 	}
 
 	existingImageList := &storagev1alpha1.ImageList{}
-	if err = h.k8sClient.List(ctx, existingImageList, client.InNamespace(registry.Namespace), client.MatchingFields{"spec.imageMetadata.registry": registry.Name}); err != nil {
+	listOpts := []client.ListOption{
+		client.InNamespace(registry.Namespace),
+		client.MatchingFields{storagev1alpha1.IndexImageMetadataRegistry: registry.Name},
+	}
+	if err = h.k8sClient.List(ctx, existingImageList, listOpts...); err != nil {
 		return fmt.Errorf("cannot list existing images in registry %s: %w", registry.Name, err)
 	}
 	existingImageNames := sets.Set[string]{}

--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -106,7 +106,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message []byte) error
 	}
 
 	// Retrieve the registry from the scan job annotations.
-	registrData, ok := scanJob.Annotations[v1alpha1.RegistryAnnotation]
+	registrData, ok := scanJob.Annotations[v1alpha1.AnnotationScanJobRegistryKey]
 	if !ok {
 		return fmt.Errorf("scan job %s/%s does not have a registry annotation", createCatalogMessage.ScanJob.Namespace, createCatalogMessage.ScanJob.Name)
 	}

--- a/internal/handlers/create_catalog_test.go
+++ b/internal/handlers/create_catalog_test.go
@@ -159,7 +159,7 @@ func TestCreateCatalogHandler_Handle(t *testing.T) {
 		WithScheme(scheme).
 		WithRuntimeObjects(registry, scanJob).
 		WithStatusSubresource(&v1alpha1.ScanJob{}).
-		WithIndex(&storagev1alpha1.Image{}, "spec.imageMetadata.registry", func(obj client.Object) []string {
+		WithIndex(&storagev1alpha1.Image{}, storagev1alpha1.IndexImageMetadataRegistry, func(obj client.Object) []string {
 			image, ok := obj.(*storagev1alpha1.Image)
 			if !ok {
 				return nil

--- a/internal/handlers/create_catalog_test.go
+++ b/internal/handlers/create_catalog_test.go
@@ -140,7 +140,7 @@ func TestCreateCatalogHandler_Handle(t *testing.T) {
 			Name:      "test-scan-job",
 			Namespace: "default",
 			Annotations: map[string]string{
-				v1alpha1.RegistryAnnotation: string(registryData),
+				v1alpha1.AnnotationScanJobRegistryKey: string(registryData),
 			},
 			UID: "scanjob-uid",
 		},
@@ -375,7 +375,7 @@ func TestCreateCatalogHandler_Handle_ObsoleteImages(t *testing.T) {
 			Name:      "test-scan-job",
 			Namespace: "default",
 			Annotations: map[string]string{
-				v1alpha1.RegistryAnnotation: string(registryData),
+				v1alpha1.AnnotationScanJobRegistryKey: string(registryData),
 			},
 			UID: "scanjob-uid",
 		},

--- a/internal/handlers/scan_sbom.go
+++ b/internal/handlers/scan_sbom.go
@@ -207,9 +207,9 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message []byte) error { //
 
 	_, err = controllerutil.CreateOrUpdate(ctx, h.k8sClient, vulnerabilityReport, func() error {
 		vulnerabilityReport.Labels = map[string]string{
-			api.LabelScanJobUIDKey: string(scanJob.UID),
-			api.LabelManagedByKey:  api.LabelManagedByValue,
-			api.LabelPartOfKey:     api.LabelPartOfValue,
+			v1alpha1.LabelScanJobUIDKey: string(scanJob.UID),
+			api.LabelManagedByKey:       api.LabelManagedByValue,
+			api.LabelPartOfKey:          api.LabelPartOfValue,
 		}
 
 		vulnerabilityReport.Spec = storagev1alpha1.VulnerabilityReportSpec{

--- a/internal/handlers/scan_sbom_test.go
+++ b/internal/handlers/scan_sbom_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/owenrumney/go-sarif/v2/sarif"
-	"github.com/rancher/sbombastic/api"
 	storagev1alpha1 "github.com/rancher/sbombastic/api/storage/v1alpha1"
 	"github.com/rancher/sbombastic/api/v1alpha1"
 	"github.com/rancher/sbombastic/pkg/generated/clientset/versioned/scheme"
@@ -194,7 +193,7 @@ func testScanSBOM(t *testing.T, cacheDir, platform, sourceSBOMJSON, expectedRepo
 
 	assert.Equal(t, sbom.GetImageMetadata(), vulnerabilityReport.GetImageMetadata())
 	assert.Equal(t, sbom.UID, vulnerabilityReport.GetOwnerReferences()[0].UID)
-	assert.Equal(t, string(scanJob.UID), vulnerabilityReport.Labels[api.LabelScanJobUIDKey])
+	assert.Equal(t, string(scanJob.UID), vulnerabilityReport.Labels[v1alpha1.LabelScanJobUIDKey])
 
 	report := &sarif.Report{}
 	err = json.Unmarshal(vulnerabilityReport.Spec.SARIF.Raw, report)

--- a/internal/webhook/v1alpha1/scanjob_webhook.go
+++ b/internal/webhook/v1alpha1/scanjob_webhook.go
@@ -56,7 +56,7 @@ func (d *ScanJobCustomDefaulter) Default(_ context.Context, obj runtime.Object) 
 	}
 
 	// Add creation timestamp annotation with nanosecond precision
-	scanJob.Annotations[v1alpha1.CreationTimestampAnnotation] = time.Now().Format(time.RFC3339Nano)
+	scanJob.Annotations[v1alpha1.AnnotationScanJobCreationTimestampKey] = time.Now().Format(time.RFC3339Nano)
 
 	return nil
 }

--- a/internal/webhook/v1alpha1/scanjob_webhook_test.go
+++ b/internal/webhook/v1alpha1/scanjob_webhook_test.go
@@ -32,7 +32,7 @@ func TestScanJobDefaulter_Default(t *testing.T) {
 	err := defaulter.Default(t.Context(), scanJob)
 	require.NoError(t, err)
 
-	timestampStr := scanJob.Annotations[v1alpha1.CreationTimestampAnnotation]
+	timestampStr := scanJob.Annotations[v1alpha1.AnnotationScanJobCreationTimestampKey]
 	assert.NotEmpty(t, timestampStr)
 
 	_, err = time.Parse(time.RFC3339Nano, timestampStr)


### PR DESCRIPTION
## Description

This PR cleans up constants by switching to prefixes instead of suffixes for type naming and moving them into the right packages where needed. It also updates all `MatchingFields` options to use constants instead of string literals for indexes.
