### PR TITLE
fix(handlers): skip creation if an image already exists

### DIFF
--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -172,6 +172,10 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message []byte) error
 			}
 
 			if err = h.k8sClient.Create(ctx, &image); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					h.logger.DebugContext(ctx, "Image already exists, skipping creation", "image", image.Name, "namespace", image.Namespace)
+					continue
+				}
 				return fmt.Errorf("cannot create image %s: %w", image.Name, err)
 			}
 		}


### PR DESCRIPTION
## Description

This fix stops race conditions when the same image ends up being created at the same time.
It can happen if someone deletes a `ScanJob` while a worker is still running and quickly starts a new one, or if two `ScanJobs` happen to pick up the same image with the same SHA in the same registry.


