### PR TITLE
doc: update VulnerabilityReport example

### DIFF
--- a/examples/vulnerabilityreport.yaml
+++ b/examples/vulnerabilityreport.yaml
@@ -1,306 +1,1850 @@
-apiVersion: storage.sbombastic.rancher.io/v1alpha1
 kind: VulnerabilityReport
+apiVersion: storage.sbombastic.rancher.io/v1alpha1
 metadata:
-  name: 82df15a51db0bb0182ee86c6d084c43d1c2731e36c68900ee59c88747dd4af10
-  namespace: default
+  name: 733d0ae8c02e45d2e31090fb8ad739b03ffcb7863bedeaa78ffdf6e4c1e34fb7
+  namespace: sbombastic
+  uid: 3d0dfedb-a25d-445a-8445-c90a95ff6b66
+  resourceVersion: "1"
+  creationTimestamp: "2025-09-02T07:38:19Z"
+  labels:
+    app.kubernetes.io/managed-by: sbombastic
+    app.kubernetes.io/part-of: sbombastic
+    sbombastic.rancher.io/scanjob-uid: 261980d5-725d-4dae-8e76-511aff62c047
+  ownerReferences:
+    - apiVersion: storage.sbombastic.rancher.io/v1alpha1
+      kind: SBOM
+      name: 733d0ae8c02e45d2e31090fb8ad739b03ffcb7863bedeaa78ffdf6e4c1e34fb7
+      uid: b6ce9c50-f705-4c29-966e-04ee16b59466
+      controller: true
+      blockOwnerDeletion: true
 spec:
   imageMetadata:
-    digest: sha256:6169c4bcc1982095067d85edf58fdcc3bd8505aef728610c5b728f3cf1cec46b
-    platform: linux/amd64
-    registry: my-first-registry
-    registryURI: docker-registry.default.svc.cluster.local
-    repository: ubuntu
-    tag: latest
-  sarif:
-    $schema: https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json
-    runs:
-      - columnKind: utf16CodeUnits
-        originalUriBaseIds:
-          ROOTPATH:
-            uri: file:///
-        results:
-          - level: note
-            locations:
-              - message:
-                  text: "/var/run/worker/trivy.sbom.2903938134.json: coreutils@9.4-3ubuntu6"
-                physicalLocation:
-                  artifactLocation:
-                    uri: /var/run/worker/trivy.sbom.2903938134.json
-                    uriBaseId: ROOTPATH
-                  region:
-                    endColumn: 1
-                    endLine: 1
-                    startColumn: 1
-                    startLine: 1
-            message:
-              text: "Package: coreutils\nInstalled Version: 9.4-3ubuntu6\nVulnerability
-                CVE-2016-2781\nSeverity: LOW\nFixed Version: \nLink: [CVE-2016-2781](https://avd.aquasec.com/nvd/cve-2016-2781)"
-            ruleId: CVE-2016-2781
-            ruleIndex: 0
-          - level: note
-            locations:
-              - message:
-                  text: "/var/run/worker/trivy.sbom.2903938134.json: gpgv@2.4.4-2ubuntu17"
-                physicalLocation:
-                  artifactLocation:
-                    uri: /var/run/worker/trivy.sbom.2903938134.json
-                    uriBaseId: ROOTPATH
-                  region:
-                    endColumn: 1
-                    endLine: 1
-                    startColumn: 1
-                    startLine: 1
-            message:
-              text: "Package: gpgv\nInstalled Version: 2.4.4-2ubuntu17\nVulnerability
-                CVE-2022-3219\nSeverity: LOW\nFixed Version: \nLink: [CVE-2022-3219](https://avd.aquasec.com/nvd/cve-2022-3219)"
-            ruleId: CVE-2022-3219
-            ruleIndex: 1
-          - level: note
-            locations:
-              - message:
-                  text: "/var/run/worker/trivy.sbom.2903938134.json: libc-bin@2.39-0ubuntu8.3"
-                physicalLocation:
-                  artifactLocation:
-                    uri: /var/run/worker/trivy.sbom.2903938134.json
-                    uriBaseId: ROOTPATH
-                  region:
-                    endColumn: 1
-                    endLine: 1
-                    startColumn: 1
-                    startLine: 1
-            message:
-              text: "Package: libc-bin\nInstalled Version: 2.39-0ubuntu8.3\nVulnerability
-                CVE-2016-20013\nSeverity: LOW\nFixed Version: \nLink: [CVE-2016-20013](https://avd.aquasec.com/nvd/cve-2016-20013)"
-            ruleId: CVE-2016-20013
-            ruleIndex: 2
-          - level: note
-            locations:
-              - message:
-                  text: "/var/run/worker/trivy.sbom.2903938134.json: libc6@2.39-0ubuntu8.3"
-                physicalLocation:
-                  artifactLocation:
-                    uri: /var/run/worker/trivy.sbom.2903938134.json
-                    uriBaseId: ROOTPATH
-                  region:
-                    endColumn: 1
-                    endLine: 1
-                    startColumn: 1
-                    startLine: 1
-            message:
-              text: "Package: libc6\nInstalled Version: 2.39-0ubuntu8.3\nVulnerability
-                CVE-2016-20013\nSeverity: LOW\nFixed Version: \nLink: [CVE-2016-20013](https://avd.aquasec.com/nvd/cve-2016-20013)"
-            ruleId: CVE-2016-20013
-            ruleIndex: 2
-          - level: warning
-            locations:
-              - message:
-                  text: "/var/run/worker/trivy.sbom.2903938134.json: libgcrypt20@1.10.3-2build1"
-                physicalLocation:
-                  artifactLocation:
-                    uri: /var/run/worker/trivy.sbom.2903938134.json
-                    uriBaseId: ROOTPATH
-                  region:
-                    endColumn: 1
-                    endLine: 1
-                    startColumn: 1
-                    startLine: 1
-            message:
-              text: "Package: libgcrypt20\nInstalled Version: 1.10.3-2build1\nVulnerability
-                CVE-2024-2236\nSeverity: MEDIUM\nFixed Version: \nLink: [CVE-2024-2236](https://avd.aquasec.com/nvd/cve-2024-2236)"
-            ruleId: CVE-2024-2236
-            ruleIndex: 3
-          - level: note
-            locations:
-              - message:
-                  text: "/var/run/worker/trivy.sbom.2903938134.json: libssl3t64@3.0.13-0ubuntu3.4"
-                physicalLocation:
-                  artifactLocation:
-                    uri: /var/run/worker/trivy.sbom.2903938134.json
-                    uriBaseId: ROOTPATH
-                  region:
-                    endColumn: 1
-                    endLine: 1
-                    startColumn: 1
-                    startLine: 1
-            message:
-              text: "Package: libssl3t64\nInstalled Version: 3.0.13-0ubuntu3.4\nVulnerability
-                CVE-2024-41996\nSeverity: LOW\nFixed Version: \nLink: [CVE-2024-41996](https://avd.aquasec.com/nvd/cve-2024-41996)"
-            ruleId: CVE-2024-41996
-            ruleIndex: 4
-        tool:
-          driver:
-            fullName: Trivy Vulnerability Scanner
-            informationUri: https://github.com/aquasecurity/trivy
-            name: Trivy
-            rules:
-              - defaultConfiguration:
-                  level: note
-                fullDescription:
-                  text: chroot in GNU coreutils, when used with --userspec, allows local
-                    users to escape to the parent session via a crafted TIOCSTI ioctl
-                    call, which pushes characters to the terminal&#39;s input buffer.
-                help:
-                  markdown: |-
-                    **Vulnerability CVE-2016-2781**
-                    | Severity | Package | Fixed Version | Link |
-                    | --- | --- | --- | --- |
-                    |LOW|coreutils||[CVE-2016-2781](https://avd.aquasec.com/nvd/cve-2016-2781)|
-
-                    chroot in GNU coreutils, when used with --userspec, allows local users to escape to the parent session via a crafted TIOCSTI ioctl call, which pushes characters to the terminal's input buffer.
-                  text: "Vulnerability CVE-2016-2781\nSeverity: LOW\nPackage: coreutils\nFixed
-                    Version: \nLink: [CVE-2016-2781](https://avd.aquasec.com/nvd/cve-2016-2781)\nchroot
-                    in GNU coreutils, when used with --userspec, allows local users to
-                    escape to the parent session via a crafted TIOCSTI ioctl call, which
-                    pushes characters to the terminal's input buffer."
-                helpUri: https://avd.aquasec.com/nvd/cve-2016-2781
-                id: CVE-2016-2781
-                name: OsPackageVulnerability
-                properties:
-                  precision: very-high
-                  security-severity: "2.0"
-                  tags:
-                    - vulnerability
-                    - security
-                    - LOW
-                shortDescription:
-                  text: "coreutils: Non-privileged session can escape to the parent session
-                    in chroot"
-              - defaultConfiguration:
-                  level: note
-                fullDescription:
-                  text: GnuPG can be made to spin on a relatively small input by (for
-                    example) crafting a public key with thousands of signatures attached,
-                    compressed down to just a few KB.
-                help:
-                  markdown: |-
-                    **Vulnerability CVE-2022-3219**
-                    | Severity | Package | Fixed Version | Link |
-                    | --- | --- | --- | --- |
-                    |LOW|gpgv||[CVE-2022-3219](https://avd.aquasec.com/nvd/cve-2022-3219)|
-
-                    GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.
-                  text: "Vulnerability CVE-2022-3219\nSeverity: LOW\nPackage: gpgv\nFixed
-                    Version: \nLink: [CVE-2022-3219](https://avd.aquasec.com/nvd/cve-2022-3219)\nGnuPG
-                    can be made to spin on a relatively small input by (for example) crafting
-                    a public key with thousands of signatures attached, compressed down
-                    to just a few KB."
-                helpUri: https://avd.aquasec.com/nvd/cve-2022-3219
-                id: CVE-2022-3219
-                name: OsPackageVulnerability
-                properties:
-                  precision: very-high
-                  security-severity: "2.0"
-                  tags:
-                    - vulnerability
-                    - security
-                    - LOW
-                shortDescription:
-                  text: "gnupg: denial of service issue (resource consumption) using compressed
-                    packets"
-              - defaultConfiguration:
-                  level: note
-                fullDescription:
-                  text: sha256crypt and sha512crypt through 0.6 allow attackers to cause
-                    a denial of service (CPU consumption) because the algorithm&#39;s
-                    runtime is proportional to the square of the length of the password.
-                help:
-                  markdown: |-
-                    **Vulnerability CVE-2016-20013**
-                    | Severity | Package | Fixed Version | Link |
-                    | --- | --- | --- | --- |
-                    |LOW|libc6||[CVE-2016-20013](https://avd.aquasec.com/nvd/cve-2016-20013)|
-
-                    sha256crypt and sha512crypt through 0.6 allow attackers to cause a denial of service (CPU consumption) because the algorithm's runtime is proportional to the square of the length of the password.
-                  text: "Vulnerability CVE-2016-20013\nSeverity: LOW\nPackage: libc6\nFixed
-                    Version: \nLink: [CVE-2016-20013](https://avd.aquasec.com/nvd/cve-2016-20013)\nsha256crypt
-                    and sha512crypt through 0.6 allow attackers to cause a denial of service
-                    (CPU consumption) because the algorithm's runtime is proportional
-                    to the square of the length of the password."
-                helpUri: https://avd.aquasec.com/nvd/cve-2016-20013
-                id: CVE-2016-20013
-                name: OsPackageVulnerability
-                properties:
-                  precision: very-high
-                  security-severity: "2.0"
-                  tags:
-                    - vulnerability
-                    - security
-                    - LOW
-                shortDescription:
-                  text: ""
-              - defaultConfiguration:
-                  level: warning
-                fullDescription:
-                  text: A timing-based side-channel flaw was found in libgcrypt&#39;s
-                    RSA implementation. This issue may allow a remote attacker to initiate
-                    a Bleichenbacher-style attack, which can lead to the decryption of
-                    RSA ciphertexts.
-                help:
-                  markdown: |-
-                    **Vulnerability CVE-2024-2236**
-                    | Severity | Package | Fixed Version | Link |
-                    | --- | --- | --- | --- |
-                    |MEDIUM|libgcrypt20||[CVE-2024-2236](https://avd.aquasec.com/nvd/cve-2024-2236)|
-
-                    A timing-based side-channel flaw was found in libgcrypt's RSA implementation. This issue may allow a remote attacker to initiate a Bleichenbacher-style attack, which can lead to the decryption of RSA ciphertexts.
-                  text: "Vulnerability CVE-2024-2236\nSeverity: MEDIUM\nPackage: libgcrypt20\nFixed
-                    Version: \nLink: [CVE-2024-2236](https://avd.aquasec.com/nvd/cve-2024-2236)\nA
-                    timing-based side-channel flaw was found in libgcrypt's RSA implementation.
-                    This issue may allow a remote attacker to initiate a Bleichenbacher-style
-                    attack, which can lead to the decryption of RSA ciphertexts."
-                helpUri: https://avd.aquasec.com/nvd/cve-2024-2236
-                id: CVE-2024-2236
-                name: OsPackageVulnerability
-                properties:
-                  precision: very-high
-                  security-severity: "5.5"
-                  tags:
-                    - vulnerability
-                    - security
-                    - MEDIUM
-                shortDescription:
-                  text: "libgcrypt: vulnerable to Marvin Attack"
-              - defaultConfiguration:
-                  level: note
-                fullDescription:
-                  text: Validating the order of the public keys in the Diffie-Hellman
-                    Key Agreement Protocol, when an approved safe prime is used, allows
-                    remote attackers (from the client side) to trigger unnecessarily expensive
-                    server-side DHE modular-exponentiation calculations. The client may
-                    cause asymmetric resource consumption. The basic attack scenario is
-                    that the client must claim that it can only communicate with DHE,
-                    and the server must be configured to allow DHE and validate the order
-                    of the public key.
-                help:
-                  markdown: |-
-                    **Vulnerability CVE-2024-41996**
-                    | Severity | Package | Fixed Version | Link |
-                    | --- | --- | --- | --- |
-                    |LOW|libssl3t64||[CVE-2024-41996](https://avd.aquasec.com/nvd/cve-2024-41996)|
-
-                    Validating the order of the public keys in the Diffie-Hellman Key Agreement Protocol, when an approved safe prime is used, allows remote attackers (from the client side) to trigger unnecessarily expensive server-side DHE modular-exponentiation calculations. The client may cause asymmetric resource consumption. The basic attack scenario is that the client must claim that it can only communicate with DHE, and the server must be configured to allow DHE and validate the order of the public key.
-                  text: "Vulnerability CVE-2024-41996\nSeverity: LOW\nPackage: libssl3t64\nFixed
-                    Version: \nLink: [CVE-2024-41996](https://avd.aquasec.com/nvd/cve-2024-41996)\nValidating
-                    the order of the public keys in the Diffie-Hellman Key Agreement Protocol,
-                    when an approved safe prime is used, allows remote attackers (from
-                    the client side) to trigger unnecessarily expensive server-side DHE
-                    modular-exponentiation calculations. The client may cause asymmetric
-                    resource consumption. The basic attack scenario is that the client
-                    must claim that it can only communicate with DHE, and the server must
-                    be configured to allow DHE and validate the order of the public key."
-                helpUri: https://avd.aquasec.com/nvd/cve-2024-41996
-                id: CVE-2024-41996
-                name: OsPackageVulnerability
-                properties:
-                  precision: very-high
-                  security-severity: "2.0"
-                  tags:
-                    - vulnerability
-                    - security
-                    - LOW
-                shortDescription:
-                  text: "openssl: remote attackers (from the client side) to trigger unnecessarily
-                    expensive server-side DHE modular-exponentiation calculations"
-            version: dev
-    version: 2.1.0
+    registry: test-registry
+    registryURI: ghcr.io
+    repository: rancher-sandbox/sbombastic/test-assets/golang
+    tag: 1.12-alpine
+    platform: linux/arm
+    digest: sha256:ab389e320938f3bd42f45437d381fab28742dadcb892816236801e24a0bef804
+  report:
+    results:
+      - target: /var/run/worker/trivy.sbom.944776516.json (alpine 3.11.3)
+        class: os-pkgs
+        type: alpine
+        vulnerabilities:
+          - cve: CVE-2021-36159
+            title: "libfetch: an out of boundary read while libfetch uses strtol to parse the relevant numbers into address bytes leads to information leak or crash"
+            packageName: apk-tools
+            purl: pkg:apk/alpine/apk-tools@2.10.4-r3?arch=armv7&distro=3.11.3
+            installedVersion: 2.10.4-r3
+            fixedVersions:
+              - 2.10.7-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\0' terminator one byte too late.
+            severity: CRITICAL
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-36159
+              - https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch
+              - https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10749
+              - https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc%40%3Cdev.kafka.apache.org%3E
+              - https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc%40%3Cusers.kafka.apache.org%3E
+              - https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7%40%3Cdev.kafka.apache.org%3E
+              - https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7%40%3Cusers.kafka.apache.org%3E
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-36159
+              - https://www.cve.org/CVERecord?id=CVE-2021-36159
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H
+                v3score: "9.1"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H
+                v3score: "9.1"
+            suppressed: false
+          - cve: CVE-2021-30139
+            packageName: apk-tools
+            purl: pkg:apk/alpine/apk-tools@2.10.4-r3?arch=armv7&distro=3.11.3
+            installedVersion: 2.10.4-r3
+            fixedVersions:
+              - 2.10.6-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.
+            severity: HIGH
+            references:
+              - https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741
+              - https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+            suppressed: false
+          - cve: CVE-2021-28831
+            title: "busybox: invalid free or segmentation fault via malformed gzip data"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r10
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-28831
+              - https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd
+              - https://lists.debian.org/debian-lts-announce/2021/04/msg00001.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/3UDQGJRECXFS5EZVDH2OI45FMO436AC4/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/Z7ZIFKPRR32ZYA3WAA2NXFA3QHHOU6FJ/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZASBW7QRRLY5V2R44MQ4QQM4CZIDHM2U/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-28831
+              - https://security.gentoo.org/glsa/202105-09
+              - https://security.netapp.com/advisory/ntap-20250509-0005/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://ubuntu.com/security/notices/USN-5179-2
+              - https://ubuntu.com/security/notices/USN-6335-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-28831
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+            suppressed: false
+          - cve: CVE-2021-42378
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42378
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42378
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42378
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42379
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42379
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42379
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42379
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42380
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42380
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42380
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42380
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42381
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42381
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42381
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42381
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42382
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42382
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42382
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42382
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42383
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42383
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42383
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://www.cve.org/CVERecord?id=CVE-2021-42383
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42384
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42384
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42384
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42384
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42385
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42385
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42385
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42385
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42386
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc()"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42386
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42386
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42386
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42374
+            title: "busybox: out-of-bounds read in unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed"
+            packageName: busybox
+            purl: pkg:apk/alpine/busybox@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that
+            severity: MEDIUM
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42374
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42374
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42374
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:H
+                v3score: "5.3"
+              redhat:
+                v3vector: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:H
+                v3score: "5.7"
+            suppressed: false
+          - cve: CVE-2021-3711
+            title: "openssl: SM2 Decryption Buffer Overflow"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1l-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the "out" parameter can be NULL and, on exit, the "outlen" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the "out" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).
+            severity: CRITICAL
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/08/26/2
+              - https://access.redhat.com/security/cve/CVE-2021-3711
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=59f5e75f3bced8fc0e130d72a3f582cf7b480b46
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=59f5e75f3bced8fc0e130d72a3f582cf7b480b46
+              - https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-3711
+              - https://rustsec.org/advisories/RUSTSEC-2021-0097.html
+              - https://security.gentoo.org/glsa/202209-02
+              - https://security.gentoo.org/glsa/202210-02
+              - https://security.netapp.com/advisory/ntap-20210827-0010
+              - https://security.netapp.com/advisory/ntap-20210827-0010/
+              - https://security.netapp.com/advisory/ntap-20211022-0003
+              - https://security.netapp.com/advisory/ntap-20211022-0003/
+              - https://security.netapp.com/advisory/ntap-20240621-0006
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://ubuntu.com/security/notices/USN-5051-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-3711
+              - https://www.debian.org/security/2021/dsa-4963
+              - https://www.openssl.org/news/secadv/20210824.txt
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujan2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-16
+              - https://www.tenable.com/security/tns-2022-02
+            cvss:
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+                v3score: "9.8"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+                v3score: "9.8"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+                v3score: "9.8"
+            suppressed: false
+          - cve: CVE-2020-1967
+            title: "openssl: Segmentation fault in SSL_check_chain causes denial of service"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1g-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the "signature_algorithms_cert" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).
+            severity: HIGH
+            references:
+              - http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html
+              - http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html
+              - http://packetstormsecurity.com/files/157527/OpenSSL-signature_algorithms_cert-Denial-Of-Service.html
+              - http://seclists.org/fulldisclosure/2020/May/5
+              - http://www.openwall.com/lists/oss-security/2020/04/22/2
+              - https://access.redhat.com/security/cve/CVE-2020-1967
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=eb563247aef3e83dda7679c43f9649270462e5b1
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=eb563247aef3e83dda7679c43f9649270462e5b1
+              - https://github.com/irsl/CVE-2020-1967
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44440
+              - https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345@%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064@%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee@%3Cdev.tomcat.apache.org%3E
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/DDHOAATPWJCXRNFMJ2SASDBBNU5RJONY/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/EXDDAOWSAIEFQNBHWYE6PPYFV4QXGMCD/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO/
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DDHOAATPWJCXRNFMJ2SASDBBNU5RJONY
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EXDDAOWSAIEFQNBHWYE6PPYFV4QXGMCD
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO
+              - https://nvd.nist.gov/vuln/detail/CVE-2020-1967
+              - https://rustsec.org/advisories/RUSTSEC-2020-0015.html
+              - https://security.FreeBSD.org/advisories/FreeBSD-SA-20:11.openssl.asc
+              - https://security.gentoo.org/glsa/202004-10
+              - https://security.netapp.com/advisory/ntap-20200424-0003
+              - https://security.netapp.com/advisory/ntap-20200424-0003/
+              - https://security.netapp.com/advisory/ntap-20200717-0004
+              - https://security.netapp.com/advisory/ntap-20200717-0004/
+              - https://www.cve.org/CVERecord?id=CVE-2020-1967
+              - https://www.debian.org/security/2020/dsa-4661
+              - https://www.openssl.org/news/secadv/20200421.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpujan2021.html
+              - https://www.oracle.com/security-alerts/cpujul2020.html
+              - https://www.oracle.com/security-alerts/cpuoct2020.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.synology.com/security/advisory/Synology_SA_20_05
+              - https://www.synology.com/security/advisory/Synology_SA_20_05_OpenSSL
+              - https://www.tenable.com/security/tns-2020-03
+              - https://www.tenable.com/security/tns-2020-04
+              - https://www.tenable.com/security/tns-2020-11
+              - https://www.tenable.com/security/tns-2021-10
+            cvss:
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+            suppressed: false
+          - cve: CVE-2021-23840
+            title: "openssl: integer overflow in CipherUpdate"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1j-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-23840
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2
+              - https://github.com/alexcrichton/openssl-src-rs
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846
+              - https://kc.mcafee.com/corporate/index?page=content&id=SB10366
+              - https://linux.oracle.com/cve/CVE-2021-23840.html
+              - https://linux.oracle.com/errata/ELSA-2021-9561.html
+              - https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E
+              - https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E
+              - https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E
+              - https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-23840
+              - https://rustsec.org/advisories/RUSTSEC-2021-0057.html
+              - https://security.gentoo.org/glsa/202103-03
+              - https://security.netapp.com/advisory/ntap-20210219-0009
+              - https://security.netapp.com/advisory/ntap-20210219-0009/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://ubuntu.com/security/notices/USN-4738-1
+              - https://ubuntu.com/security/notices/USN-5088-1
+              - https://ubuntu.com/security/notices/USN-7018-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-23840
+              - https://www.debian.org/security/2021/dsa-4855
+              - https://www.openssl.org/news/secadv/20210216.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujan2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-03
+              - https://www.tenable.com/security/tns-2021-09
+              - https://www.tenable.com/security/tns-2021-10
+            cvss:
+              bitnami:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+            suppressed: false
+          - cve: CVE-2021-3450
+            title: "openssl: CA certificate check bypass with X509_V_FLAG_X509_STRICT"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1k-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a "purpose" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named "purpose" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).
+            severity: HIGH
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/03/27/1
+              - http://www.openwall.com/lists/oss-security/2021/03/27/2
+              - http://www.openwall.com/lists/oss-security/2021/03/28/3
+              - http://www.openwall.com/lists/oss-security/2021/03/28/4
+              - https://access.redhat.com/security/cve/CVE-2021-3450
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b
+              - https://github.com/alexcrichton/openssl-src-rs
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845
+              - https://kc.mcafee.com/corporate/index?page=content&id=SB10356
+              - https://linux.oracle.com/cve/CVE-2021-3450.html
+              - https://linux.oracle.com/errata/ELSA-2021-9151.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP
+              - https://mta.openssl.org/pipermail/openssl-announce/2021-March/000198.html
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-3450
+              - https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013
+              - https://rustsec.org/advisories/RUSTSEC-2021-0056.html
+              - https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc
+              - https://security.gentoo.org/glsa/202103-03
+              - https://security.netapp.com/advisory/ntap-20210326-0006
+              - https://security.netapp.com/advisory/ntap-20210326-0006/
+              - https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd
+              - https://www.cve.org/CVERecord?id=CVE-2021-3450
+              - https://www.openssl.org/news/secadv/20210325.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujul2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-05
+              - https://www.tenable.com/security/tns-2021-08
+              - https://www.tenable.com/security/tns-2021-09
+            cvss:
+              bitnami:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+                v3score: "7.4"
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+                v3score: "7.4"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+                v3score: "7.4"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+                v3score: "7.4"
+            suppressed: false
+          - cve: CVE-2021-3712
+            title: "openssl: Read buffer overruns processing ASN.1 strings"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1l-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own "d2i" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the "data" and "length" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the "data" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).
+            severity: HIGH
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/08/26/2
+              - https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json
+              - https://access.redhat.com/security/cve/CVE-2021-3712
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-244969.pdf
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=94d23fcff9b2a7a8368dfe52214d5c2569882c11
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=ccb0a11145ee72b042d10593a64eaf9e8a55ec12
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=94d23fcff9b2a7a8368dfe52214d5c2569882c11
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ccb0a11145ee72b042d10593a64eaf9e8a55ec12
+              - https://kc.mcafee.com/corporate/index?page=content&id=SB10366
+              - https://linux.oracle.com/cve/CVE-2021-3712.html
+              - https://linux.oracle.com/errata/ELSA-2022-9023.html
+              - https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E
+              - https://lists.debian.org/debian-lts-announce/2021/09/msg00014.html
+              - https://lists.debian.org/debian-lts-announce/2021/09/msg00021.html
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-3712
+              - https://rustsec.org/advisories/RUSTSEC-2021-0098.html
+              - https://security.gentoo.org/glsa/202209-02
+              - https://security.gentoo.org/glsa/202210-02
+              - https://security.netapp.com/advisory/ntap-20210827-0010
+              - https://security.netapp.com/advisory/ntap-20210827-0010/
+              - https://security.netapp.com/advisory/ntap-20240621-0006
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://ubuntu.com/security/notices/USN-5051-1
+              - https://ubuntu.com/security/notices/USN-5051-2
+              - https://ubuntu.com/security/notices/USN-5051-3
+              - https://ubuntu.com/security/notices/USN-5051-4 (regression only in trusty/esm)
+              - https://ubuntu.com/security/notices/USN-5088-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-3712
+              - https://www.debian.org/security/2021/dsa-4963
+              - https://www.openssl.org/news/secadv/20210824.txt
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujan2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-16
+              - https://www.tenable.com/security/tns-2022-02
+            cvss:
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H
+                v3score: "7.4"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H
+                v3score: "7.4"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H
+                v3score: "7.4"
+            suppressed: false
+          - cve: CVE-2020-1971
+            title: "openssl: EDIPARTYNAME NULL pointer de-reference"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1i-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: 'The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL''s s_server, s_client and verify tools have support for the "-crl_download" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL''s parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).'
+            severity: MEDIUM
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/09/14/2
+              - https://access.redhat.com/security/cve/CVE-2020-1971
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=f960d81215ebf3f65e03d4d5d857fb9b666d6920
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44676
+              - https://linux.oracle.com/cve/CVE-2020-1971.html
+              - https://linux.oracle.com/errata/ELSA-2021-9150.html
+              - https://lists.apache.org/thread.html/r63c6f2dd363d9b514d0a4bcf624580616a679898cc14c109a49b750c%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rbb769f771711fb274e0a4acb1b5911c8aab544a6ac5e8c12d40c5143%40%3Ccommits.pulsar.apache.org%3E
+              - https://lists.debian.org/debian-lts-announce/2020/12/msg00020.html
+              - https://lists.debian.org/debian-lts-announce/2020/12/msg00021.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/DGSI34Y5LQ5RYXN4M2I5ZQT65LFVDOUU/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/PWPSSZNZOBJU2YR6Z4TGHXKYW3YP5QG7/
+              - https://nvd.nist.gov/vuln/detail/CVE-2020-1971
+              - https://security.FreeBSD.org/advisories/FreeBSD-SA-20:33.openssl.asc
+              - https://security.gentoo.org/glsa/202012-13
+              - https://security.netapp.com/advisory/ntap-20201218-0005/
+              - https://security.netapp.com/advisory/ntap-20210513-0002/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://ubuntu.com/security/notices/USN-4662-1
+              - https://ubuntu.com/security/notices/USN-4745-1
+              - https://www.cve.org/CVERecord?id=CVE-2020-1971
+              - https://www.debian.org/security/2020/dsa-4807
+              - https://www.openssl.org/news/secadv/20201208.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujan2021.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2020-11
+              - https://www.tenable.com/security/tns-2021-09
+              - https://www.tenable.com/security/tns-2021-10
+            cvss:
+              bitnami:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+            suppressed: false
+          - cve: CVE-2021-23841
+            title: "openssl: NULL pointer dereference in X509_issuer_and_serial_hash()"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1j-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).
+            severity: MEDIUM
+            references:
+              - http://seclists.org/fulldisclosure/2021/May/67
+              - http://seclists.org/fulldisclosure/2021/May/68
+              - http://seclists.org/fulldisclosure/2021/May/70
+              - https://access.redhat.com/security/cve/CVE-2021-23841
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=122a19ab48091c657f7cb1fb3af9fc07bd557bbf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2
+              - https://github.com/alexcrichton/openssl-src-rs
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846
+              - https://linux.oracle.com/cve/CVE-2021-23841.html
+              - https://linux.oracle.com/errata/ELSA-2021-9561.html
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-23841
+              - https://rustsec.org/advisories/RUSTSEC-2021-0058
+              - https://rustsec.org/advisories/RUSTSEC-2021-0058.html
+              - https://security.gentoo.org/glsa/202103-03
+              - https://security.netapp.com/advisory/ntap-20210219-0009
+              - https://security.netapp.com/advisory/ntap-20210219-0009/
+              - https://security.netapp.com/advisory/ntap-20210513-0002
+              - https://security.netapp.com/advisory/ntap-20210513-0002/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://support.apple.com/kb/HT212528
+              - https://support.apple.com/kb/HT212529
+              - https://support.apple.com/kb/HT212534
+              - https://ubuntu.com/security/notices/USN-4738-1
+              - https://ubuntu.com/security/notices/USN-4745-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-23841
+              - https://www.debian.org/security/2021/dsa-4855
+              - https://www.openssl.org/news/secadv/20210216.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-03
+              - https://www.tenable.com/security/tns-2021-09
+            cvss:
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+            suppressed: false
+          - cve: CVE-2021-3449
+            title: "openssl: NULL pointer dereference in signature_algorithms processing"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1k-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).
+            severity: MEDIUM
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/03/27/1
+              - http://www.openwall.com/lists/oss-security/2021/03/27/2
+              - http://www.openwall.com/lists/oss-security/2021/03/28/3
+              - http://www.openwall.com/lists/oss-security/2021/03/28/4
+              - https://access.redhat.com/security/cve/CVE-2021-3449
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-772220.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=fb9fa6b51defd48157eeb207f52181f735d96148
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fb9fa6b51defd48157eeb207f52181f735d96148
+              - https://github.com/alexcrichton/openssl-src-rs
+              - https://github.com/nodejs/node/pull/38083
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845
+              - https://kc.mcafee.com/corporate/index?page=content&id=SB10356
+              - https://linux.oracle.com/cve/CVE-2021-3449.html
+              - https://linux.oracle.com/errata/ELSA-2021-9151.html
+              - https://lists.debian.org/debian-lts-announce/2021/08/msg00029.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-3449
+              - https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013
+              - https://rustsec.org/advisories/RUSTSEC-2021-0055
+              - https://rustsec.org/advisories/RUSTSEC-2021-0055.html
+              - https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc
+              - https://security.gentoo.org/glsa/202103-03
+              - https://security.netapp.com/advisory/ntap-20210326-0006
+              - https://security.netapp.com/advisory/ntap-20210326-0006/
+              - https://security.netapp.com/advisory/ntap-20210513-0002
+              - https://security.netapp.com/advisory/ntap-20210513-0002/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd
+              - https://ubuntu.com/security/notices/USN-4891-1
+              - https://ubuntu.com/security/notices/USN-5038-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-3449
+              - https://www.debian.org/security/2021/dsa-4875
+              - https://www.openssl.org/news/secadv/20210325.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujul2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-05
+              - https://www.tenable.com/security/tns-2021-06
+              - https://www.tenable.com/security/tns-2021-09
+              - https://www.tenable.com/security/tns-2021-10
+            cvss:
+              bitnami:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+            suppressed: false
+          - cve: CVE-2021-23839
+            title: "openssl: incorrect SSLv2 rollback protection"
+            packageName: libcrypto1.1
+            purl: pkg:apk/alpine/libcrypto1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1j-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x)."
+            severity: LOW
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-23839
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=30919ab80a478f2d81f2e9acdcca3fa4740cd547
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-23839
+              - https://security.netapp.com/advisory/ntap-20210219-0009/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://www.cve.org/CVERecord?id=CVE-2021-23839
+              - https://www.openssl.org/news/secadv/20210216.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N
+                v3score: "3.7"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N
+                v3score: "3.7"
+            suppressed: false
+          - cve: CVE-2021-3711
+            title: "openssl: SM2 Decryption Buffer Overflow"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1l-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the "out" parameter can be NULL and, on exit, the "outlen" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the "out" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).
+            severity: CRITICAL
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/08/26/2
+              - https://access.redhat.com/security/cve/CVE-2021-3711
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=59f5e75f3bced8fc0e130d72a3f582cf7b480b46
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=59f5e75f3bced8fc0e130d72a3f582cf7b480b46
+              - https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-3711
+              - https://rustsec.org/advisories/RUSTSEC-2021-0097.html
+              - https://security.gentoo.org/glsa/202209-02
+              - https://security.gentoo.org/glsa/202210-02
+              - https://security.netapp.com/advisory/ntap-20210827-0010
+              - https://security.netapp.com/advisory/ntap-20210827-0010/
+              - https://security.netapp.com/advisory/ntap-20211022-0003
+              - https://security.netapp.com/advisory/ntap-20211022-0003/
+              - https://security.netapp.com/advisory/ntap-20240621-0006
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://ubuntu.com/security/notices/USN-5051-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-3711
+              - https://www.debian.org/security/2021/dsa-4963
+              - https://www.openssl.org/news/secadv/20210824.txt
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujan2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-16
+              - https://www.tenable.com/security/tns-2022-02
+            cvss:
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+                v3score: "9.8"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+                v3score: "9.8"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+                v3score: "9.8"
+            suppressed: false
+          - cve: CVE-2020-1967
+            title: "openssl: Segmentation fault in SSL_check_chain causes denial of service"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1g-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the "signature_algorithms_cert" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).
+            severity: HIGH
+            references:
+              - http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html
+              - http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html
+              - http://packetstormsecurity.com/files/157527/OpenSSL-signature_algorithms_cert-Denial-Of-Service.html
+              - http://seclists.org/fulldisclosure/2020/May/5
+              - http://www.openwall.com/lists/oss-security/2020/04/22/2
+              - https://access.redhat.com/security/cve/CVE-2020-1967
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=eb563247aef3e83dda7679c43f9649270462e5b1
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=eb563247aef3e83dda7679c43f9649270462e5b1
+              - https://github.com/irsl/CVE-2020-1967
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44440
+              - https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345@%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064@%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee@%3Cdev.tomcat.apache.org%3E
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/DDHOAATPWJCXRNFMJ2SASDBBNU5RJONY/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/EXDDAOWSAIEFQNBHWYE6PPYFV4QXGMCD/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO/
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DDHOAATPWJCXRNFMJ2SASDBBNU5RJONY
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EXDDAOWSAIEFQNBHWYE6PPYFV4QXGMCD
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO
+              - https://nvd.nist.gov/vuln/detail/CVE-2020-1967
+              - https://rustsec.org/advisories/RUSTSEC-2020-0015.html
+              - https://security.FreeBSD.org/advisories/FreeBSD-SA-20:11.openssl.asc
+              - https://security.gentoo.org/glsa/202004-10
+              - https://security.netapp.com/advisory/ntap-20200424-0003
+              - https://security.netapp.com/advisory/ntap-20200424-0003/
+              - https://security.netapp.com/advisory/ntap-20200717-0004
+              - https://security.netapp.com/advisory/ntap-20200717-0004/
+              - https://www.cve.org/CVERecord?id=CVE-2020-1967
+              - https://www.debian.org/security/2020/dsa-4661
+              - https://www.openssl.org/news/secadv/20200421.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpujan2021.html
+              - https://www.oracle.com/security-alerts/cpujul2020.html
+              - https://www.oracle.com/security-alerts/cpuoct2020.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.synology.com/security/advisory/Synology_SA_20_05
+              - https://www.synology.com/security/advisory/Synology_SA_20_05_OpenSSL
+              - https://www.tenable.com/security/tns-2020-03
+              - https://www.tenable.com/security/tns-2020-04
+              - https://www.tenable.com/security/tns-2020-11
+              - https://www.tenable.com/security/tns-2021-10
+            cvss:
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+            suppressed: false
+          - cve: CVE-2021-23840
+            title: "openssl: integer overflow in CipherUpdate"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1j-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-23840
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2
+              - https://github.com/alexcrichton/openssl-src-rs
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846
+              - https://kc.mcafee.com/corporate/index?page=content&id=SB10366
+              - https://linux.oracle.com/cve/CVE-2021-23840.html
+              - https://linux.oracle.com/errata/ELSA-2021-9561.html
+              - https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E
+              - https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E
+              - https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E
+              - https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-23840
+              - https://rustsec.org/advisories/RUSTSEC-2021-0057.html
+              - https://security.gentoo.org/glsa/202103-03
+              - https://security.netapp.com/advisory/ntap-20210219-0009
+              - https://security.netapp.com/advisory/ntap-20210219-0009/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://ubuntu.com/security/notices/USN-4738-1
+              - https://ubuntu.com/security/notices/USN-5088-1
+              - https://ubuntu.com/security/notices/USN-7018-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-23840
+              - https://www.debian.org/security/2021/dsa-4855
+              - https://www.openssl.org/news/secadv/20210216.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujan2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-03
+              - https://www.tenable.com/security/tns-2021-09
+              - https://www.tenable.com/security/tns-2021-10
+            cvss:
+              bitnami:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+            suppressed: false
+          - cve: CVE-2021-3450
+            title: "openssl: CA certificate check bypass with X509_V_FLAG_X509_STRICT"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1k-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a "purpose" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named "purpose" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).
+            severity: HIGH
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/03/27/1
+              - http://www.openwall.com/lists/oss-security/2021/03/27/2
+              - http://www.openwall.com/lists/oss-security/2021/03/28/3
+              - http://www.openwall.com/lists/oss-security/2021/03/28/4
+              - https://access.redhat.com/security/cve/CVE-2021-3450
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b
+              - https://github.com/alexcrichton/openssl-src-rs
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845
+              - https://kc.mcafee.com/corporate/index?page=content&id=SB10356
+              - https://linux.oracle.com/cve/CVE-2021-3450.html
+              - https://linux.oracle.com/errata/ELSA-2021-9151.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP
+              - https://mta.openssl.org/pipermail/openssl-announce/2021-March/000198.html
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-3450
+              - https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013
+              - https://rustsec.org/advisories/RUSTSEC-2021-0056.html
+              - https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc
+              - https://security.gentoo.org/glsa/202103-03
+              - https://security.netapp.com/advisory/ntap-20210326-0006
+              - https://security.netapp.com/advisory/ntap-20210326-0006/
+              - https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd
+              - https://www.cve.org/CVERecord?id=CVE-2021-3450
+              - https://www.openssl.org/news/secadv/20210325.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujul2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-05
+              - https://www.tenable.com/security/tns-2021-08
+              - https://www.tenable.com/security/tns-2021-09
+            cvss:
+              bitnami:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+                v3score: "7.4"
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+                v3score: "7.4"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+                v3score: "7.4"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+                v3score: "7.4"
+            suppressed: false
+          - cve: CVE-2021-3712
+            title: "openssl: Read buffer overruns processing ASN.1 strings"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1l-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own "d2i" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the "data" and "length" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the "data" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).
+            severity: HIGH
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/08/26/2
+              - https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json
+              - https://access.redhat.com/security/cve/CVE-2021-3712
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-244969.pdf
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=94d23fcff9b2a7a8368dfe52214d5c2569882c11
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=ccb0a11145ee72b042d10593a64eaf9e8a55ec12
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=94d23fcff9b2a7a8368dfe52214d5c2569882c11
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ccb0a11145ee72b042d10593a64eaf9e8a55ec12
+              - https://kc.mcafee.com/corporate/index?page=content&id=SB10366
+              - https://linux.oracle.com/cve/CVE-2021-3712.html
+              - https://linux.oracle.com/errata/ELSA-2022-9023.html
+              - https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E
+              - https://lists.debian.org/debian-lts-announce/2021/09/msg00014.html
+              - https://lists.debian.org/debian-lts-announce/2021/09/msg00021.html
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-3712
+              - https://rustsec.org/advisories/RUSTSEC-2021-0098.html
+              - https://security.gentoo.org/glsa/202209-02
+              - https://security.gentoo.org/glsa/202210-02
+              - https://security.netapp.com/advisory/ntap-20210827-0010
+              - https://security.netapp.com/advisory/ntap-20210827-0010/
+              - https://security.netapp.com/advisory/ntap-20240621-0006
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://ubuntu.com/security/notices/USN-5051-1
+              - https://ubuntu.com/security/notices/USN-5051-2
+              - https://ubuntu.com/security/notices/USN-5051-3
+              - https://ubuntu.com/security/notices/USN-5051-4 (regression only in trusty/esm)
+              - https://ubuntu.com/security/notices/USN-5088-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-3712
+              - https://www.debian.org/security/2021/dsa-4963
+              - https://www.openssl.org/news/secadv/20210824.txt
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujan2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-16
+              - https://www.tenable.com/security/tns-2022-02
+            cvss:
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H
+                v3score: "7.4"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H
+                v3score: "7.4"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H
+                v3score: "7.4"
+            suppressed: false
+          - cve: CVE-2020-1971
+            title: "openssl: EDIPARTYNAME NULL pointer de-reference"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1i-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: 'The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL''s s_server, s_client and verify tools have support for the "-crl_download" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL''s parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).'
+            severity: MEDIUM
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/09/14/2
+              - https://access.redhat.com/security/cve/CVE-2020-1971
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=f960d81215ebf3f65e03d4d5d857fb9b666d6920
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44676
+              - https://linux.oracle.com/cve/CVE-2020-1971.html
+              - https://linux.oracle.com/errata/ELSA-2021-9150.html
+              - https://lists.apache.org/thread.html/r63c6f2dd363d9b514d0a4bcf624580616a679898cc14c109a49b750c%40%3Cdev.tomcat.apache.org%3E
+              - https://lists.apache.org/thread.html/rbb769f771711fb274e0a4acb1b5911c8aab544a6ac5e8c12d40c5143%40%3Ccommits.pulsar.apache.org%3E
+              - https://lists.debian.org/debian-lts-announce/2020/12/msg00020.html
+              - https://lists.debian.org/debian-lts-announce/2020/12/msg00021.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/DGSI34Y5LQ5RYXN4M2I5ZQT65LFVDOUU/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/PWPSSZNZOBJU2YR6Z4TGHXKYW3YP5QG7/
+              - https://nvd.nist.gov/vuln/detail/CVE-2020-1971
+              - https://security.FreeBSD.org/advisories/FreeBSD-SA-20:33.openssl.asc
+              - https://security.gentoo.org/glsa/202012-13
+              - https://security.netapp.com/advisory/ntap-20201218-0005/
+              - https://security.netapp.com/advisory/ntap-20210513-0002/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://ubuntu.com/security/notices/USN-4662-1
+              - https://ubuntu.com/security/notices/USN-4745-1
+              - https://www.cve.org/CVERecord?id=CVE-2020-1971
+              - https://www.debian.org/security/2020/dsa-4807
+              - https://www.openssl.org/news/secadv/20201208.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujan2021.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2020-11
+              - https://www.tenable.com/security/tns-2021-09
+              - https://www.tenable.com/security/tns-2021-10
+            cvss:
+              bitnami:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+            suppressed: false
+          - cve: CVE-2021-23841
+            title: "openssl: NULL pointer dereference in X509_issuer_and_serial_hash()"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1j-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).
+            severity: MEDIUM
+            references:
+              - http://seclists.org/fulldisclosure/2021/May/67
+              - http://seclists.org/fulldisclosure/2021/May/68
+              - http://seclists.org/fulldisclosure/2021/May/70
+              - https://access.redhat.com/security/cve/CVE-2021-23841
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=122a19ab48091c657f7cb1fb3af9fc07bd557bbf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2
+              - https://github.com/alexcrichton/openssl-src-rs
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846
+              - https://linux.oracle.com/cve/CVE-2021-23841.html
+              - https://linux.oracle.com/errata/ELSA-2021-9561.html
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-23841
+              - https://rustsec.org/advisories/RUSTSEC-2021-0058
+              - https://rustsec.org/advisories/RUSTSEC-2021-0058.html
+              - https://security.gentoo.org/glsa/202103-03
+              - https://security.netapp.com/advisory/ntap-20210219-0009
+              - https://security.netapp.com/advisory/ntap-20210219-0009/
+              - https://security.netapp.com/advisory/ntap-20210513-0002
+              - https://security.netapp.com/advisory/ntap-20210513-0002/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://support.apple.com/kb/HT212528
+              - https://support.apple.com/kb/HT212529
+              - https://support.apple.com/kb/HT212534
+              - https://ubuntu.com/security/notices/USN-4738-1
+              - https://ubuntu.com/security/notices/USN-4745-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-23841
+              - https://www.debian.org/security/2021/dsa-4855
+              - https://www.openssl.org/news/secadv/20210216.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-03
+              - https://www.tenable.com/security/tns-2021-09
+            cvss:
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+            suppressed: false
+          - cve: CVE-2021-3449
+            title: "openssl: NULL pointer dereference in signature_algorithms processing"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1k-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).
+            severity: MEDIUM
+            references:
+              - http://www.openwall.com/lists/oss-security/2021/03/27/1
+              - http://www.openwall.com/lists/oss-security/2021/03/27/2
+              - http://www.openwall.com/lists/oss-security/2021/03/28/3
+              - http://www.openwall.com/lists/oss-security/2021/03/28/4
+              - https://access.redhat.com/security/cve/CVE-2021-3449
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-772220.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=fb9fa6b51defd48157eeb207f52181f735d96148
+              - https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fb9fa6b51defd48157eeb207f52181f735d96148
+              - https://github.com/alexcrichton/openssl-src-rs
+              - https://github.com/nodejs/node/pull/38083
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845
+              - https://kc.mcafee.com/corporate/index?page=content&id=SB10356
+              - https://linux.oracle.com/cve/CVE-2021-3449.html
+              - https://linux.oracle.com/errata/ELSA-2021-9151.html
+              - https://lists.debian.org/debian-lts-announce/2021/08/msg00029.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/
+              - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-3449
+              - https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013
+              - https://rustsec.org/advisories/RUSTSEC-2021-0055
+              - https://rustsec.org/advisories/RUSTSEC-2021-0055.html
+              - https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc
+              - https://security.gentoo.org/glsa/202103-03
+              - https://security.netapp.com/advisory/ntap-20210326-0006
+              - https://security.netapp.com/advisory/ntap-20210326-0006/
+              - https://security.netapp.com/advisory/ntap-20210513-0002
+              - https://security.netapp.com/advisory/ntap-20210513-0002/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd
+              - https://ubuntu.com/security/notices/USN-4891-1
+              - https://ubuntu.com/security/notices/USN-5038-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-3449
+              - https://www.debian.org/security/2021/dsa-4875
+              - https://www.openssl.org/news/secadv/20210325.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpujul2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+              - https://www.tenable.com/security/tns-2021-05
+              - https://www.tenable.com/security/tns-2021-06
+              - https://www.tenable.com/security/tns-2021-09
+              - https://www.tenable.com/security/tns-2021-10
+            cvss:
+              bitnami:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              ghsa:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.9"
+            suppressed: false
+          - cve: CVE-2021-23839
+            title: "openssl: incorrect SSLv2 rollback protection"
+            packageName: libssl1.1
+            purl: pkg:apk/alpine/libssl1.1@1.1.1d-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.1d-r3
+            fixedVersions:
+              - 1.1.1j-r0
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x)."
+            severity: LOW
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-23839
+              - https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf
+              - https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=30919ab80a478f2d81f2e9acdcca3fa4740cd547
+              - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-23839
+              - https://security.netapp.com/advisory/ntap-20210219-0009/
+              - https://security.netapp.com/advisory/ntap-20240621-0006/
+              - https://www.cve.org/CVERecord?id=CVE-2021-23839
+              - https://www.openssl.org/news/secadv/20210216.txt
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuApr2021.html
+              - https://www.oracle.com/security-alerts/cpuapr2022.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N
+                v3score: "3.7"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N
+                v3score: "3.7"
+            suppressed: false
+          - cve: CVE-2020-28928
+            title: In musl libc through 1.2.1, wcsnrtombs mishandles particular combinati ...
+            packageName: musl
+            purl: pkg:apk/alpine/musl@1.1.24-r0?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.24-r0
+            fixedVersions:
+              - 1.1.24-r3
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).
+            severity: MEDIUM
+            references:
+              - http://www.openwall.com/lists/oss-security/2020/11/20/4
+              - https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E
+              - https://lists.apache.org/thread.html/r90b60cf49348e515257b4950900c1bd3ab95a960cf2469d919c7264e%40%3Cnotifications.apisix.apache.org%3E
+              - https://lists.apache.org/thread.html/ra63e8dc5137d952afc55dbbfa63be83304ecf842d1eab1ff3ebb29e2%40%3Cnotifications.apisix.apache.org%3E
+              - https://lists.debian.org/debian-lts-announce/2020/11/msg00050.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LKQ3RVSMVZNZNO4D65W2CZZ4DMYFZN2Q/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UW27QVY7ERPTSGKS4KAWE5TU7EJWHKVQ/
+              - https://musl.libc.org/releases.html
+              - https://ubuntu.com/security/notices/USN-5990-1
+              - https://www.cve.org/CVERecord?id=CVE-2020-28928
+              - https://www.openwall.com/lists/oss-security/2020/11/20/4
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.5"
+            suppressed: false
+          - cve: CVE-2020-28928
+            title: In musl libc through 1.2.1, wcsnrtombs mishandles particular combinati ...
+            packageName: musl-utils
+            purl: pkg:apk/alpine/musl-utils@1.1.24-r0?arch=armv7&distro=3.11.3
+            installedVersion: 1.1.24-r0
+            fixedVersions:
+              - 1.1.24-r3
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).
+            severity: MEDIUM
+            references:
+              - http://www.openwall.com/lists/oss-security/2020/11/20/4
+              - https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E
+              - https://lists.apache.org/thread.html/r90b60cf49348e515257b4950900c1bd3ab95a960cf2469d919c7264e%40%3Cnotifications.apisix.apache.org%3E
+              - https://lists.apache.org/thread.html/ra63e8dc5137d952afc55dbbfa63be83304ecf842d1eab1ff3ebb29e2%40%3Cnotifications.apisix.apache.org%3E
+              - https://lists.debian.org/debian-lts-announce/2020/11/msg00050.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LKQ3RVSMVZNZNO4D65W2CZZ4DMYFZN2Q/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UW27QVY7ERPTSGKS4KAWE5TU7EJWHKVQ/
+              - https://musl.libc.org/releases.html
+              - https://ubuntu.com/security/notices/USN-5990-1
+              - https://www.cve.org/CVERecord?id=CVE-2020-28928
+              - https://www.openwall.com/lists/oss-security/2020/11/20/4
+              - https://www.oracle.com//security-alerts/cpujul2021.html
+              - https://www.oracle.com/security-alerts/cpuoct2021.html
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+                v3score: "5.5"
+            suppressed: false
+          - cve: CVE-2021-28831
+            title: "busybox: invalid free or segmentation fault via malformed gzip data"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r10
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-28831
+              - https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd
+              - https://lists.debian.org/debian-lts-announce/2021/04/msg00001.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/3UDQGJRECXFS5EZVDH2OI45FMO436AC4/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/Z7ZIFKPRR32ZYA3WAA2NXFA3QHHOU6FJ/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZASBW7QRRLY5V2R44MQ4QQM4CZIDHM2U/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-28831
+              - https://security.gentoo.org/glsa/202105-09
+              - https://security.netapp.com/advisory/ntap-20250509-0005/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://ubuntu.com/security/notices/USN-5179-2
+              - https://ubuntu.com/security/notices/USN-6335-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-28831
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+                v3score: "7.5"
+            suppressed: false
+          - cve: CVE-2021-42378
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42378
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42378
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42378
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42379
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42379
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42379
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42379
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42380
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42380
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42380
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42380
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42381
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42381
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42381
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42381
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42382
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42382
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42382
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42382
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42383
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42383
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42383
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://www.cve.org/CVERecord?id=CVE-2021-42383
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42384
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42384
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42384
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42384
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42385
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42385
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42385
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42385
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42386
+            title: "busybox: use-after-free in awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc()"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function
+            severity: HIGH
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42386
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42386
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42386
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "7.2"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+                v3score: "6.6"
+            suppressed: false
+          - cve: CVE-2021-42374
+            title: "busybox: out-of-bounds read in unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed"
+            packageName: ssl_client
+            purl: pkg:apk/alpine/ssl_client@1.31.1-r9?arch=armv7&distro=3.11.3
+            installedVersion: 1.31.1-r9
+            fixedVersions:
+              - 1.31.1-r11
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that
+            severity: MEDIUM
+            references:
+              - https://access.redhat.com/security/cve/CVE-2021-42374
+              - https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog
+              - https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6T2TURBYYJGBMQTTN2DSOAIQGP7WCPGV/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UQXGOGWBIYWOIVXJVRKHZR34UMEHQBXS/
+              - https://nvd.nist.gov/vuln/detail/CVE-2021-42374
+              - https://security.netapp.com/advisory/ntap-20211223-0002/
+              - https://ubuntu.com/security/notices/USN-5179-1
+              - https://www.cve.org/CVERecord?id=CVE-2021-42374
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:H
+                v3score: "5.3"
+              redhat:
+                v3vector: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:H
+                v3score: "5.7"
+            suppressed: false
+          - cve: CVE-2022-37434
+            title: "zlib: heap-based buffer over-read and overflow in inflate() in inflate.c via a large gzip header extra field"
+            packageName: zlib
+            purl: pkg:apk/alpine/zlib@1.2.11-r3?arch=armv7&distro=3.11.3
+            installedVersion: 1.2.11-r3
+            fixedVersions:
+              - 1.2.11-r4
+            diffID: sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026
+            description: "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference)."
+            severity: CRITICAL
+            references:
+              - http://seclists.org/fulldisclosure/2022/Oct/37
+              - http://seclists.org/fulldisclosure/2022/Oct/38
+              - http://seclists.org/fulldisclosure/2022/Oct/41
+              - http://seclists.org/fulldisclosure/2022/Oct/42
+              - http://www.openwall.com/lists/oss-security/2022/08/05/2
+              - http://www.openwall.com/lists/oss-security/2022/08/09/1
+              - https://access.redhat.com/errata/RHSA-2022:8291
+              - https://access.redhat.com/security/cve/CVE-2022-37434
+              - https://bugzilla.redhat.com/2116639
+              - https://bugzilla.redhat.com/show_bug.cgi?id=2053198
+              - https://bugzilla.redhat.com/show_bug.cgi?id=2077431
+              - https://bugzilla.redhat.com/show_bug.cgi?id=2081296
+              - https://bugzilla.redhat.com/show_bug.cgi?id=2116639
+              - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-37434
+              - https://errata.almalinux.org/9/ALSA-2022-8291.html
+              - https://errata.rockylinux.org/RLSA-2022:8291
+              - https://github.com/curl/curl/issues/9271
+              - https://github.com/ivd38/zlib_overflow
+              - https://github.com/madler/zlib/blob/21767c654d31d2dccdde4330529775c6c5fd5389/zlib.h#L1062-L1063
+              - https://github.com/madler/zlib/commit/1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d
+              - https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1
+              - https://github.com/nodejs/node/blob/75b68c6e4db515f76df73af476eccf382bbcb00a/deps/zlib/inflate.c#L762-L764
+              - https://linux.oracle.com/cve/CVE-2022-37434.html
+              - https://linux.oracle.com/errata/ELSA-2023-1095.html
+              - https://lists.debian.org/debian-lts-announce/2022/09/msg00012.html
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JWN4VE3JQR4O2SOUS5TXNLANRPMHWV4I/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/NMBOJ77A7T7PQCARMDUK75TE6LLESZ3O/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/PAVPQNCG3XRLCLNSQRM3KAN5ZFMVXVTY/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/X5U7OTKZSHY2I3ZFJSR2SHFHW72RKGDK/
+              - https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/YRQAI7H4M4RQZ2IWZUEEXECBE5D56BH2/
+              - https://nvd.nist.gov/vuln/detail/CVE-2022-37434
+              - https://security.netapp.com/advisory/ntap-20220901-0005/
+              - https://security.netapp.com/advisory/ntap-20230427-0007/
+              - https://support.apple.com/kb/HT213488
+              - https://support.apple.com/kb/HT213489
+              - https://support.apple.com/kb/HT213490
+              - https://support.apple.com/kb/HT213491
+              - https://support.apple.com/kb/HT213493
+              - https://support.apple.com/kb/HT213494
+              - https://ubuntu.com/security/notices/USN-5570-1
+              - https://ubuntu.com/security/notices/USN-5570-2
+              - https://ubuntu.com/security/notices/USN-5573-1
+              - https://ubuntu.com/security/notices/USN-6736-1
+              - https://ubuntu.com/security/notices/USN-6736-2
+              - https://www.cve.org/CVERecord?id=CVE-2022-37434
+              - https://www.debian.org/security/2022/dsa-5218
+            cvss:
+              nvd:
+                v3vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+                v3score: "9.8"
+              redhat:
+                v3vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H
+                v3score: "7"
+            suppressed: false
 status: {}


### PR DESCRIPTION
Update the example of the VulnerabilityReport that we ship with our code to reflect the new format we just introduced.


JFYI: this is a dump of a VulnerabilityReport created by our e2e tests