### PR TITLE
fix(api): registry scanInterval optional

### DIFF
--- a/api/v1alpha1/registry_types.go
+++ b/api/v1alpha1/registry_types.go
@@ -13,7 +13,9 @@ type RegistrySpec struct {
 	Repositories []string `json:"repositories,omitempty"`
 	// AuthSecret is the name of the secret in the same namespace that contains the credentials to access the registry.
 	AuthSecret string `json:"authSecret,omitempty"`
-	// ScanInterval is the interval at which the registry is scanned. Set to 0 to disable automatic scanning.
+	// ScanInterval is the interval at which the registry is scanned.
+	// If not set, automatic scanning is disabled.
+	// +kubebuilder:validation:Optional
 	ScanInterval metav1.Duration `json:"scanInterval"`
 	// CABundle is the CA bundle to use when connecting to the registry.
 	CABundle string `json:"caBundle,omitempty"`

--- a/charts/sbombastic/templates/crd/sbombastic.rancher.io_registries.yaml
+++ b/charts/sbombastic/templates/crd/sbombastic.rancher.io_registries.yaml
@@ -63,14 +63,13 @@ spec:
                   type: string
                 type: array
               scanInterval:
-                description: ScanInterval is the interval at which the registry is
-                  scanned. Set to 0 to disable automatic scanning.
+                description: |-
+                  ScanInterval is the interval at which the registry is scanned.
+                  If not set, automatic scanning is disabled.
                 type: string
               uri:
                 description: URI is the URI of the container registry
                 type: string
-            required:
-            - scanInterval
             type: object
           status:
             description: RegistryStatus defines the observed state of Registry


### PR DESCRIPTION
## Description

This PR makes `scanInterval` optional; leaving it unset disables automatic scanning.
