### PR TITLE
fix(handlers): ack messages when an error occurs and fix status update conflict

### DIFF
--- a/internal/messaging/subscriber.go
+++ b/internal/messaging/subscriber.go
@@ -78,11 +78,11 @@ func (s *NatsSubscriber) Run(ctx context.Context) error {
 							"error", err,
 						)
 					}
-				}
 
-				// Return early to avoid acking a message that failed processing.
-				// This allows the message to be retried later even if the nak fails.
-				return
+					// Return early to avoid acking a message that failed processing.
+					// This allows the message to be retried later even if the nak fails.
+					return
+				}
 			}
 
 			if err := msg.Ack(); err != nil {


### PR DESCRIPTION
## Description

This PR addresses an edge case where the handler updates the status condition faster than the controller, leading to conflicts.
It also corrects a misplaced early return that was triggering infinite job retries.