### PR TITLE
feat: add Registry webhook

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -17,6 +17,9 @@ resources:
   kind: Registry
   path: github.com/rancher/sbombastic/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -38,7 +41,6 @@ resources:
   version: v1alpha1
 - api:
     crdVersion: v1
-    namespaced: false
   domain: sbombastic.rancher.io
   group: sbombastic
   kind: VEXHub

--- a/Tiltfile
+++ b/Tiltfile
@@ -93,6 +93,7 @@ local_resource(
         "api",
         "internal/controller",
         "internal/messaging",
+        "internal/webhook",
     ],
 )
 

--- a/charts/sbombastic/templates/controller/webhooks.yaml
+++ b/charts/sbombastic/templates/controller/webhooks.yaml
@@ -8,27 +8,27 @@ metadata:
     {{ include "sbombastic.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
 webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: {{ include "sbombastic.fullname" . }}-controller-webhook
-      namespace: {{ .Release.Namespace }}
-      path: /mutate-sbombastic-rancher-io-v1alpha1-scanjob
-  failurePolicy: Fail
-  name: mscanjob.sbombastic.rancher.io
-  rules:
-  - apiGroups:
-    - sbombastic.rancher.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - scanjobs
-  sideEffects: None
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "sbombastic.fullname" . }}-controller-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-sbombastic-rancher-io-v1alpha1-scanjob
+    failurePolicy: Fail
+    name: mscanjob.sbombastic.rancher.io
+    rules:
+    - apiGroups:
+      - sbombastic.rancher.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - scanjobs
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -40,24 +40,45 @@ metadata:
     {{ include "sbombastic.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
 webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: {{ include "sbombastic.fullname" . }}-controller-webhook
-      namespace: {{ .Release.Namespace }}
-      path: /validate-sbombastic-rancher-io-v1alpha1-scanjob
-  failurePolicy: Fail
-  name: vscanjob.sbombastic.rancher.io
-  rules:
-  - apiGroups:
-    - sbombastic.rancher.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - scanjobs
-  sideEffects: None
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "sbombastic.fullname" . }}-controller-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /validate-sbombastic-rancher-io-v1alpha1-scanjob
+    failurePolicy: Fail
+    name: vscanjob.sbombastic.rancher.io
+    rules:
+    - apiGroups:
+      - sbombastic.rancher.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - scanjobs
+    sideEffects: None
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "sbombastic.fullname" . }}-controller-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /validate-sbombastic-rancher-io-v1alpha1-registry
+    failurePolicy: Fail
+    name: vregistry.sbombastic.rancher.io
+    rules:
+    - apiGroups:
+      - sbombastic.rancher.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - registries
+    sideEffects: None

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -234,6 +234,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = webhookv1alpha1.SetupRegistryWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "Registry")
+		os.Exit(1)
+	}
+
 	if err = webhookv1alpha1.SetupScanJobWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ScanJob")
 		os.Exit(1)

--- a/internal/webhook/v1alpha1/registry_webhook.go
+++ b/internal/webhook/v1alpha1/registry_webhook.go
@@ -1,0 +1,114 @@
+package v1alpha1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/rancher/sbombastic/api/v1alpha1"
+)
+
+// SetupRegistryWebhookWithManager registers the webhook for Registry in the manager.
+func SetupRegistryWebhookWithManager(mgr ctrl.Manager) error {
+	err := ctrl.NewWebhookManagedBy(mgr).For(&v1alpha1.Registry{}).
+		WithValidator(&RegistryCustomValidator{
+			logger: mgr.GetLogger().WithName("registry_validator"),
+		}).
+		Complete()
+	if err != nil {
+		return fmt.Errorf("failed to setup Registry webhook: %w", err)
+	}
+	return nil
+}
+
+// +kubebuilder:webhook:path=/validate-sbombastic-sbombastic-rancher-io-v1alpha1-registry,mutating=false,failurePolicy=fail,sideEffects=None,groups=sbombastic.sbombastic.rancher.io,resources=registries,verbs=create;update,versions=v1alpha1,name=vregistry-v1alpha1.kb.io,admissionReviewVersions=v1
+
+type RegistryCustomValidator struct {
+	logger logr.Logger
+}
+
+var _ webhook.CustomValidator = &RegistryCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Registry.
+func (v *RegistryCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	registry, ok := obj.(*v1alpha1.Registry)
+	if !ok {
+		return nil, fmt.Errorf("expected a Registry object but got %T", obj)
+	}
+	v.logger.Info("Validation for Registry upon creation", "name", registry.GetName())
+
+	var allErrs field.ErrorList
+
+	if err := validateScanInterval(registry); err != nil {
+		fieldPath := field.NewPath("spec").Child("scanInterval")
+		allErrs = append(allErrs, field.Invalid(fieldPath, registry.Spec.ScanInterval, err.Error()))
+	}
+
+	if len(allErrs) > 0 {
+		return nil, apierrors.NewInvalid(
+			v1alpha1.GroupVersion.WithKind("Registry").GroupKind(),
+			registry.Name,
+			allErrs,
+		)
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Registry.
+func (v *RegistryCustomValidator) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+	registry, ok := newObj.(*v1alpha1.Registry)
+	if !ok {
+		return nil, fmt.Errorf("expected a Registry object for the newObj but got %T", newObj)
+	}
+	v.logger.Info("Validation for Registry upon update", "name", registry.GetName())
+
+	var allErrs field.ErrorList
+
+	if err := validateScanInterval(registry); err != nil {
+		fieldPath := field.NewPath("spec").Child("scanInterval")
+		allErrs = append(allErrs, field.Invalid(fieldPath, registry.Spec.ScanInterval, err.Error()))
+	}
+
+	if len(allErrs) > 0 {
+		return nil, apierrors.NewInvalid(
+			v1alpha1.GroupVersion.WithKind("Registry").GroupKind(),
+			registry.Name,
+			allErrs,
+		)
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Registry.
+func (v *RegistryCustomValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	registry, ok := obj.(*v1alpha1.Registry)
+	if !ok {
+		return nil, fmt.Errorf("expected a Registry object but got %T", obj)
+	}
+	v.logger.Info("Validation for Registry upon deletion", "name", registry.GetName())
+
+	return nil, nil
+}
+
+func validateScanInterval(registry *v1alpha1.Registry) error {
+	if registry.Spec.ScanInterval == nil {
+		return nil
+	}
+	if registry.Spec.ScanInterval.Duration < time.Minute {
+		return errors.New("scanInterval must be at least 1 minute")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
This PR adds the `Registry` validating webhook.
For now, it just validates the `scanInterval` field, which must be `>1m`. 

This PR also fixes #400. When a webhook is set up, the API server decodes the Registry object, which means the duration field gets parsed correctly. Before, without the webhook, this didn’t happen and the value was just stored as-is in etcd. I decided not to add a test for this, since it would need an e2e test that basically checks if the API server decoder itself is working.