### PR TITLE
chore: Automate Golang version update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25.0"
+          go-version-file: "go.mod"
       - run: make test
       - name: Upload unit-tests coverage to Codecov
         uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25.0"
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25.0"
+          go-version-file: "go.mod"
       - name: Free up disk space
         # This is a workaround to avoud the "no space left on device" error when pulling the vulbanrability database.
         # We should move to self-hosted runners or enterprise runners to avoid this issue.

--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Update SBOMbastic charts
         env:
+          # Until this repository is under the rancher-sandbox GitHub organisation
+          # It's easier to use the default GITHUB_TOKEN but ultimately
+          # it's gonna be better to use a GitHub App token
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
-        run: "updatecli apply --config ./updatecli/updatecli.d/helm-chart-update.yaml --values updatecli/values.yaml"
+        run: "updatecli compose apply --file updatecli/updatecli-compose.release.yaml"

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,28 @@
+name: Updatecli
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every hour
+    - cron: "0 * * * *"
+jobs:
+  updatecli:
+    name: Run Updatecli
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for updatecli to update the repository
+      pull-requests: write # for updatecli to create a PR
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@a327da0e796f543b8fa4706e5ed63014852ead0e # v2.91.0
+
+      - name: Run updatecli apply
+        env:
+          # Until this repository is under the rancher-sandbox GitHub organisation
+          # It's easier to use the default GITHUB_TOKEN but ultimately
+          # it's gonna be better to use a GitHub App token
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: "updatecli compose apply --file updatecli/updatecli-compose.yaml"

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,9 +1,19 @@
 name: Updatecli
 on:
+  # Allow to manually trigger Updatecli
   workflow_dispatch:
+  # Trigger Updatecli on main branch changes
+  # To rebase existing PR
+  push:
+    branches: [main]
+  # Trigger Updatecli pullrequest to test potential changes
+  pull_request:
+    branches: [main]
+  # Periodically checks update
   schedule:
     # Run every hour
     - cron: "0 * * * *"
+
 jobs:
   updatecli:
     name: Run Updatecli

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@a327da0e796f543b8fa4706e5ed63014852ead0e # v2.91.0
 
-      - name: [DRY-RUN] Run Updatecli
+      - name: Run Updatecli (dryrun)
         if: github.ref != 'refs/heads/main'
         env:
           # Until this repository is under the rancher-sandbox GitHub organisation

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -28,7 +28,18 @@ jobs:
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@a327da0e796f543b8fa4706e5ed63014852ead0e # v2.91.0
 
-      - name: Run updatecli apply
+      - name: [DRY-RUN] Run Updatecli
+        if: github.ref != 'refs/heads/main'
+        env:
+          # Until this repository is under the rancher-sandbox GitHub organisation
+          # It's easier to use the default GITHUB_TOKEN but ultimately
+          # it's gonna be better to use a GitHub App token
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: "updatecli compose diff --file updatecli/updatecli-compose.yaml"
+
+      - name: Run Updatecli
+        if: github.ref == 'refs/heads/main'
         env:
           # Until this repository is under the rancher-sandbox GitHub organisation
           # It's easier to use the default GITHUB_TOKEN but ultimately

--- a/updatecli/updatecli-compose.release.yaml
+++ b/updatecli/updatecli-compose.release.yaml
@@ -1,0 +1,6 @@
+policies:
+  - name: Update Helm Chart
+    config:
+      - "updatecli.release.d"
+    values:
+      - values.yaml

--- a/updatecli/updatecli-compose.yaml
+++ b/updatecli/updatecli-compose.yaml
@@ -1,0 +1,6 @@
+policies:
+  - name: Update Go version
+    config:
+      - "updatecli.d"
+    values:
+      - values.yaml

--- a/updatecli/updatecli.d/go.yaml
+++ b/updatecli/updatecli.d/go.yaml
@@ -68,6 +68,6 @@ scms:
       branch: "{{ .github.branch }}"
       commitmessage:
         type: "deps"
-        title: "Update Golang version"
+        title: "update Golang version"
         hidecredit: true
         footers: "Signed-off-by: SBOMbastic bot <sbombastic-bot@users.noreply.github.com>"

--- a/updatecli/updatecli.d/go.yaml
+++ b/updatecli/updatecli.d/go.yaml
@@ -67,7 +67,8 @@ scms:
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
       commitmessage:
-        type: "deps"
+        type: "chore"
+        scope: deps
         title: "update Golang version"
         hidecredit: true
         footers: "Signed-off-by: SBOMbastic bot <sbombastic-bot@users.noreply.github.com>"

--- a/updatecli/updatecli.d/go.yaml
+++ b/updatecli/updatecli.d/go.yaml
@@ -1,0 +1,73 @@
+name: Update Golang version
+
+pipelineid: golang/version
+
+sources:
+  go:
+    name: Get latest Golang version
+    kind: golang
+
+conditions:
+  docker:
+    name: Check Docker image tag
+    kind: dockerimage
+    sourceid: go
+    spec:
+      image: golang
+
+targets:
+  gomod:
+    name: 'deps(go): update Go version to {{ source "go" }}'
+    sourceid: go
+    kind: golang/gomod
+    scmid: default
+    spec:
+      file: go.mod
+
+  dockerfile:
+    name: "deps(go): update Docker image tag"
+    kind: dockerfile
+    sourceid: go
+    scmid: default
+    spec:
+      files:
+        - Dockerfile.controller
+        - Dockerfile.storage
+        - Dockerfile.worker
+      instruction:
+        keyword: FROM
+        matcher: golang
+
+actions:
+  default:
+    title: 'deps(go): update Go to {{ source "go" }} version'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Golang version {{ source "go" }} update.
+        This PR has been created by the automation used to automatically update the Golang version in the SBOMbastic project
+        REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
+      draft: false
+      labels:
+        - "chore"
+        - "dependencies"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "sbombastic"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitmessage:
+        type: "deps"
+        title: "Update Golang version"
+        hidecredit: true
+        footers: "Signed-off-by: SBOMbastic bot <sbombastic-bot@users.noreply.github.com>"

--- a/updatecli/updatecli.release.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.release.d/helm-chart-update.yaml
@@ -13,9 +13,9 @@ sources:
     name: "Get latest sbombastic version"
     kind: githubrelease
     spec:
-      owner: '{{ requiredEnv .github.owner }}'
+      owner: "{{ requiredEnv .github.owner }}"
       repository: sbombastic
-      token: '{{ requiredEnv .github.token }}'
+      token: "{{ requiredEnv .github.token }}"
       typefilter:
         prerelease: true
         release: true
@@ -30,7 +30,6 @@ scms:
     spec:
       user: "{{ .github.author }}"
       email: "{{ .github.email }}"
-      directory: "/tmp/helm-charts"
       owner: "{{ requiredEnv .github.owner }}"
       repository: "sbombastic"
       token: "{{ requiredEnv .github.token }}"
@@ -99,3 +98,4 @@ targets:
     spec:
       file: charts/sbombastic/values.yaml
       key: $.worker.image.tag
+


### PR DESCRIPTION
## Description

To automate the Golang version update, this pull request introduces the following changes

### Unset Golang version from GHA workflow

To reduce the number of Golang version, we need to update after new
Golang version, I configure the GitHub action workflow to use
the version defined in the project go.mod
More information on:
  * https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file

## Check Golang version update

Add an Updatecli manifest to monitor the Golang version defined in the Dockerfile and the go.mod
Add a new GHA workflow to run Updatecli every hour to check for update.
I used the Updatecli compose file to make it easier in the future to add more automation

## refactor the Helm chart automate update

Simplify the GHA workflow used for updating helm chart which rely on Updatecli to use an Updatecli compose file
to make it easier in the future to add more update pipeline

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Right now tested manually

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
