### PR TITLE
fix(handlers): stop the generate sbom job when the ScanJob is deleted

### DIFF
--- a/internal/controller/scanjob_controller.go
+++ b/internal/controller/scanjob_controller.go
@@ -109,7 +109,7 @@ func (r *ScanJobReconciler) reconcileScanJob(ctx context.Context, scanJob *v1alp
 		return ctrl.Result{}, fmt.Errorf("failed to update ScanJob with registry data: %w", err)
 	}
 
-	messageID := string(scanJob.UID)
+	messageID := fmt.Sprintf("createCatalog/%s", scanJob.GetUID())
 	message, err := json.Marshal(&handlers.CreateCatalogMessage{
 		BaseMessage: handlers.BaseMessage{
 			ScanJob: handlers.ObjectRef{

--- a/internal/controller/scanjob_controller_test.go
+++ b/internal/controller/scanjob_controller_test.go
@@ -72,7 +72,7 @@ var _ = Describe("ScanJob Controller", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			mockPublisher.On("Publish", mock.Anything, handlers.CreateCatalogSubject, string(scanJob.GetUID()), message).Return(nil)
+			mockPublisher.On("Publish", mock.Anything, handlers.CreateCatalogSubject, fmt.Sprintf("createCatalog/%s", scanJob.GetUID()), message).Return(nil)
 
 			By("Reconciling the ScanJob")
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
@@ -265,7 +265,7 @@ var _ = Describe("ScanJob Controller", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			mockPublisher.On("Publish", mock.Anything, handlers.CreateCatalogSubject, string(newScanJob.GetUID()), expectedMessage).Return(nil)
+			mockPublisher.On("Publish", mock.Anything, handlers.CreateCatalogSubject, fmt.Sprintf("createCatalog/%s", newScanJob.GetUID()), expectedMessage).Return(nil)
 
 			By("Reconciling the new ScanJob")
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -233,7 +233,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message []byte) error
 	for _, image := range discoveredImages {
 		h.logger.DebugContext(ctx, "Sending generate SBOM  message", "image", image.Name, "namespace", image.Namespace)
 
-		messageID := fmt.Sprintf("%s/%s", scanJob.UID, image.Name)
+		messageID := fmt.Sprintf("generateSBOM/%s/%s", scanJob.UID, image.Name)
 		message, err := json.Marshal(&GenerateSBOMMessage{
 			BaseMessage: BaseMessage{
 				ScanJob: createCatalogMessage.ScanJob,

--- a/internal/handlers/create_catalog_test.go
+++ b/internal/handlers/create_catalog_test.go
@@ -222,14 +222,14 @@ func TestCreateCatalogHandler_Handle(t *testing.T) {
 	mockPublisher.On("Publish",
 		mock.Anything,
 		GenerateSBOMSubject,
-		fmt.Sprintf("%s/%s", scanJob.UID, amd64ImageName),
+		fmt.Sprintf("generateSBOM/%s/%s", scanJob.UID, amd64ImageName),
 		expectedMessageAmd64,
 	).Return(nil).Once()
 
 	mockPublisher.On("Publish",
 		mock.Anything,
 		GenerateSBOMSubject,
-		fmt.Sprintf("%s/%s", scanJob.UID, arm64ImageName),
+		fmt.Sprintf("generateSBOM/%s/%s", scanJob.UID, arm64ImageName),
 		expectedMessageArm64,
 	).Return(nil).Once()
 
@@ -403,7 +403,7 @@ func TestCreateCatalogHandler_Handle_ObsoleteImages(t *testing.T) {
 	mockPublisher.On("Publish",
 		mock.Anything,
 		GenerateSBOMSubject,
-		fmt.Sprintf("%s/%s", scanJob.UID, existingImage.Name),
+		fmt.Sprintf("generateSBOM/%s/%s", scanJob.UID, existingImage.Name),
 		expectedMessage,
 	).Return(nil).Once()
 
@@ -865,7 +865,7 @@ func TestCreateCatalogHandler_Handle_PrivateRegistry(t *testing.T) {
 	mockPublisher.On("Publish",
 		mock.Anything,
 		GenerateSBOMSubject,
-		fmt.Sprintf("%s/%s", scanJob.UID, amd64ImageName),
+		fmt.Sprintf("generateSBOM/%s/%s", scanJob.UID, amd64ImageName),
 		expectedMessageAmd64,
 	).Return(nil).Once()
 

--- a/internal/handlers/generate_sbom.go
+++ b/internal/handlers/generate_sbom.go
@@ -123,7 +123,7 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message []byte) error 
 		h.logger.DebugContext(ctx, "SBOM already exists, skipping generation", "sbom", sbom.Name, "namespace", sbom.Namespace)
 	}
 
-	scanSBOMMessageID := fmt.Sprintf("%s/%s", scanJob.UID, sbom.Name)
+	scanSBOMMessageID := fmt.Sprintf("scanSBOM/%s/%s", scanJob.UID, sbom.Name)
 	scanSBOMMessage, err := json.Marshal(&ScanSBOMMessage{
 		BaseMessage: generateSBOMMessage.BaseMessage,
 		SBOM: ObjectRef{

--- a/internal/handlers/generate_sbom_test.go
+++ b/internal/handlers/generate_sbom_test.go
@@ -154,7 +154,7 @@ func testGenerateSBOM(t *testing.T, platform, sha256, expectedSPDXJSON string) {
 	publisher.On("Publish",
 		mock.Anything,
 		ScanSBOMSubject,
-		fmt.Sprintf("%s/%s", scanJob.UID, image.Name),
+		fmt.Sprintf("scanSBOM/%s/%s", scanJob.UID, image.Name),
 		expectedScanMessage,
 	).Return(nil).Once()
 
@@ -287,7 +287,7 @@ func TestGenerateSBOMHandler_Handle_ExistingSBOM(t *testing.T) {
 	publisher.On("Publish",
 		mock.Anything,
 		ScanSBOMSubject,
-		fmt.Sprintf("%s/%s", scanJob.UID, existingSBOM.Name),
+		fmt.Sprintf("scanSBOM/%s/%s", scanJob.UID, existingSBOM.Name),
 		expectedScanMessage,
 	).Return(nil).Once()
 
@@ -411,7 +411,7 @@ func TestGenerateSBOMHandler_Handle_PrivateRegistry(t *testing.T) {
 	publisher.On("Publish",
 		mock.Anything,
 		ScanSBOMSubject,
-		fmt.Sprintf("%s/%s", scanJob.UID, image.Name),
+		fmt.Sprintf("scanSBOM/%s/%s", scanJob.UID, image.Name),
 		expectedScanMessage,
 	).Return(nil).Once()
 


### PR DESCRIPTION
## Description

This PR fixes the SBOM generation handler, which was previously returning an error instead of skipping when a scan job was not found.
It also corrects the ScanImage NATS message ID used for deduplication.

Fixes #387 