### PR TITLE
feat: allow user to customize resources

### DIFF
--- a/charts/sbombastic/templates/controller/deployment.yaml
+++ b/charts/sbombastic/templates/controller/deployment.yaml
@@ -46,13 +46,10 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- if and .Values.controller .Values.controller.resources }}
           resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 10m
-              memory: 64Mi
+{{ toYaml .Values.controller.resources | indent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: "/tmp/k8s-webhook-server/serving-certs"
               name: webhook-tls

--- a/charts/sbombastic/templates/storage/deployment.yaml
+++ b/charts/sbombastic/templates/storage/deployment.yaml
@@ -30,6 +30,10 @@ spec:
             - -log-level={{ .Values.storage.logLevel }}
           {{- end }}
           imagePullPolicy: {{ .Values.storage.image.pullPolicy }}
+          {{- if and .Values.storage .Values.storage.resources }}
+          resources:
+{{ toYaml .Values.storage.resources | indent 12 }}
+          {{- end }}
           volumeMounts:
             - name: sqlite-pvc
               mountPath: /data/sqlite/

--- a/charts/sbombastic/templates/worker/deployment.yaml
+++ b/charts/sbombastic/templates/worker/deployment.yaml
@@ -31,6 +31,10 @@ spec:
             {{- if .Values.worker.logLevel }}
             - -log-level={{ .Values.worker.logLevel }}
             {{- end }}
+          {{- if and .Values.worker .Values.worker.resources }}
+          resources:
+{{ toYaml .Values.worker.resources | indent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /var/run/worker
               name: run-volume

--- a/charts/sbombastic/tests/controller/deployment_test.yaml
+++ b/charts/sbombastic/tests/controller/deployment_test.yaml
@@ -2,7 +2,7 @@ suite: "Controller Deployment Tests"
 templates:
   - "templates/controller/deployment.yaml"
 tests:
-  - it: "should render a Deployment with the correct replica count, logging level, image, and imagePullPolicy"
+  - it: "should render a Deployment with the correct replica count, logging level, image, resources and imagePullPolicy"
     set:
       global:
         cattle:
@@ -14,6 +14,13 @@ tests:
           repository: rancher-sandbox/sbombastic/controller
           tag: v0.1.0
           pullPolicy: Always
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 200Mi
     asserts:
       - equal:
           path: "spec.replicas"
@@ -27,3 +34,16 @@ tests:
       - contains:
           path: "spec.template.spec.containers[0].args"
           content: "-log-level=debug"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.limits.cpu"
+          value: "500m"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.limits.memory"
+          value: "1Gi"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.requests.cpu"
+          value: "250m"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.requests.memory"
+          value: "200Mi"
+

--- a/charts/sbombastic/tests/storage/deployment_test.yaml
+++ b/charts/sbombastic/tests/storage/deployment_test.yaml
@@ -4,7 +4,7 @@ templates:
   - "templates/storage/deployment.yaml"
 
 tests:
-  - it: "should render a Deployment with the correct replica count, logging level, image, and imagePullPolicy"
+  - it: "should render a Deployment with the correct replica count, logging level, image, resources, and imagePullPolicy"
     set:
       global:
         cattle:
@@ -18,6 +18,13 @@ tests:
           pullPolicy: Always
         persistence:
           name: sqlite-pvc-test
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 200Mi
     asserts:
       - equal:
           path: "spec.replicas"
@@ -34,6 +41,18 @@ tests:
       - equal:
           path: "spec.template.spec.volumes[0].persistentVolumeClaim.claimName"
           value: "RELEASE-NAME-sbombastic-storage-data"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.limits.cpu"
+          value: "500m"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.limits.memory"
+          value: "1Gi"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.requests.cpu"
+          value: "250m"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.requests.memory"
+          value: "200Mi"
   - it: "should use existing PVC claim name when persistence.storageData.existingClaim is specified"
     set:
       persistence:

--- a/charts/sbombastic/tests/worker/deployment_test.yaml
+++ b/charts/sbombastic/tests/worker/deployment_test.yaml
@@ -4,7 +4,7 @@ templates:
   - "templates/worker/deployment.yaml"
 
 tests:
-  - it: "should render a Deployment with the correct replica count, logging level, image, and imagePullPolicy"
+  - it: "should render a Deployment with the correct replica count, logging level, image, resources and imagePullPolicy"
     set:
       global:
         cattle:
@@ -16,6 +16,13 @@ tests:
           repository: rancher-sandbox/sbombastic/worker
           tag: v0.1.0
           pullPolicy: Always
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 200Mi
     asserts:
       - equal:
           path: "spec.replicas"
@@ -29,3 +36,15 @@ tests:
       - contains:
           path: "spec.template.spec.containers[0].args"
           content: "-log-level=debug"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.limits.cpu"
+          value: "500m"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.limits.memory"
+          value: "1Gi"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.requests.cpu"
+          value: "250m"
+      - equal:
+          path: "spec.template.spec.containers[0].resources.requests.memory"
+          value: "200Mi"

--- a/charts/sbombastic/values.yaml
+++ b/charts/sbombastic/values.yaml
@@ -14,6 +14,13 @@ controller:
     pullPolicy: IfNotPresent
   replicas: 3
   logLevel: "info"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 2Gi
+    requests:
+      cpu: 250m
+      memory: 300Mi
 
 storage:
   image:
@@ -22,6 +29,13 @@ storage:
     pullPolicy: IfNotPresent
   replicas: 1
   # logLevel: "debug" //TODO: uncomment this, when the log parser in storage is implemented
+  resources:
+    limits:
+      cpu: 500m
+      memory: 3Gi
+    requests:
+      cpu: 250m
+      memory: 300Mi
 
 worker:
   image:
@@ -30,6 +44,13 @@ worker:
     pullPolicy: IfNotPresent
   replicas: 3
   logLevel: "info"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 300Mi
 
 persistence:
   enabled: true


### PR DESCRIPTION
Allow the user to tune the resources (CPU, memory) that SBOMbastic pods are allowed to use.

Currently the limits of the controller are too low, when a scanjob happens the reconciler can exceed the amount of memory the controller is entitled to use. As a result, the controller is terminated by the OOM killer.

Warning: let's discuss what kind of limits and requests we should put as default values for the different components of the stack.
