### PR TITLE
fix(handlers): use info level for regular logging instead of debug

### DIFF
--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -70,7 +70,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message []byte) error
 		return fmt.Errorf("cannot unmarshal message: %w", err)
 	}
 
-	h.logger.DebugContext(ctx, "Catalog creation requested",
+	h.logger.InfoContext(ctx, "Catalog creation requested",
 		"scanjob", createCatalogMessage.ScanJob.Name,
 		"namespace", createCatalogMessage.ScanJob.Namespace,
 	)
@@ -197,10 +197,10 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message []byte) error
 			if existingImageNames.Has(image.Name) {
 				continue
 			}
-
+			h.logger.InfoContext(ctx, "Creating image", "image", image.Name, "namespace", image.Namespace)
 			if err = h.k8sClient.Create(ctx, &image); err != nil {
 				if apierrors.IsAlreadyExists(err) {
-					h.logger.DebugContext(ctx, "Image already exists, skipping creation", "image", image.Name, "namespace", image.Namespace)
+					h.logger.InfoContext(ctx, "Image already exists, skipping creation", "image", image.Name, "namespace", image.Namespace)
 					continue
 				}
 				return fmt.Errorf("cannot create image %s: %w", image.Name, err)
@@ -227,10 +227,10 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message []byte) error
 		}
 
 		if len(discoveredImages) == 0 {
-			h.logger.DebugContext(ctx, "No images to process", "scanjob", scanJob.Name, "namespace", scanJob.Namespace)
+			h.logger.InfoContext(ctx, "No images to process", "scanjob", scanJob.Name, "namespace", scanJob.Namespace)
 			scanJob.MarkComplete(v1alpha1.ReasonNoImagesToScan, "No images to process")
 		} else {
-			h.logger.DebugContext(ctx, "Images to process", "count", len(discoveredImages))
+			h.logger.InfoContext(ctx, "Images to process", "count", len(discoveredImages))
 			scanJob.MarkInProgress(v1alpha1.ReasonSBOMGenerationInProgress, "SBOM generation in progress")
 			scanJob.Status.ImagesCount = len(discoveredImages)
 			scanJob.Status.ScannedImagesCount = 0

--- a/internal/handlers/generate_sbom.go
+++ b/internal/handlers/generate_sbom.go
@@ -57,7 +57,7 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message []byte) error 
 		return fmt.Errorf("failed to unmarshal GenerateSBOM message: %w", err)
 	}
 
-	h.logger.DebugContext(ctx, "SBOM generation requested",
+	h.logger.InfoContext(ctx, "SBOM generation requested",
 		"image", generateSBOMMessage.Image.Name,
 		"namespace", generateSBOMMessage.Image.Namespace,
 	)
@@ -112,7 +112,7 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message []byte) error 
 	// Check if the SBOM already exists.
 	// If the SBOM already exists this is a no-op, since the SBOM of an image does not change.
 	if apierrors.IsNotFound(err) { //nolint:gocritic // It's easier to read this way.
-		h.logger.DebugContext(ctx, "SBOM not found, generating new one", "sbom", generateSBOMMessage.Image.Name, "namespace", generateSBOMMessage.Image.Namespace)
+		h.logger.InfoContext(ctx, "SBOM not found, generating new one", "sbom", generateSBOMMessage.Image.Name, "namespace", generateSBOMMessage.Image.Namespace)
 		sbom, err = h.generateSBOM(ctx, image, registry, generateSBOMMessage)
 		if err != nil {
 			return err
@@ -120,7 +120,7 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message []byte) error 
 	} else if err != nil {
 		return fmt.Errorf("failed to check if SBOM %s in namespace %s exists: %w", generateSBOMMessage.Image.Name, generateSBOMMessage.Image.Namespace, err)
 	} else {
-		h.logger.DebugContext(ctx, "SBOM already exists, skipping generation", "sbom", sbom.Name, "namespace", sbom.Namespace)
+		h.logger.InfoContext(ctx, "SBOM already exists, skipping generation", "sbom", sbom.Name, "namespace", sbom.Namespace)
 	}
 
 	scanSBOMMessageID := fmt.Sprintf("scanSBOM/%s/%s", scanJob.UID, sbom.Name)

--- a/internal/handlers/scan_sbom.go
+++ b/internal/handlers/scan_sbom.go
@@ -71,7 +71,7 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message []byte) error { //
 		return fmt.Errorf("failed to unmarshal scan job message: %w", err)
 	}
 
-	h.logger.DebugContext(ctx, "SBOM scan requested",
+	h.logger.InfoContext(ctx, "SBOM scan requested",
 		"sbom", scanSBOMMessage.SBOM.Name,
 		"namespace", scanSBOMMessage.SBOM.Namespace,
 	)
@@ -193,7 +193,7 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message []byte) error { //
 		return fmt.Errorf("failed to execute trivy: %w", err)
 	}
 
-	h.logger.DebugContext(ctx, "SBOM scanned",
+	h.logger.InfoContext(ctx, "SBOM scanned",
 		"sbom", scanSBOMMessage.SBOM.Name,
 		"namespace", scanSBOMMessage.SBOM.Namespace,
 	)


### PR DESCRIPTION
## Description

use info level for regular logging instead of debug in the handlers