### PR TITLE
chore(dependabot): add k8s.io/api to the kubernetes group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     groups:
       kubernetes:
         patterns:
+          - "k8s.io/api"
           - "k8s.io/apimachinery"
           - "k8s.io/client-go"
           - "k8s.io/apiserver"


### PR DESCRIPTION
## Description

Adds k8s.io/api to the dependabot kubernetes group