### PR TITLE
feat: add custom columns to storage types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -477,7 +477,11 @@ linters:
         linters:
           - revive
         text: "dot-imports"
-      # Disable dupl from api types
+      # Disable dupl for api types
       - path: 'api/.*\.go'
+        linters:
+          - dupl
+      # Disable dupl for storage package
+      - path: ^internal/storage/.*\.go$
         linters:
           - dupl

--- a/internal/storage/table_convertor.go
+++ b/internal/storage/table_convertor.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/rancher/sbombastic/api/storage/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// imageMetadataTableColumns returns the common table columns for resources that
+// implement the ImageMetadataAccessor interface.
+func imageMetadataTableColumns() []metav1.TableColumnDefinition {
+	return []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Description: "Name"},
+		{Name: "Reference", Type: "string", Description: "Image reference"},
+		{Name: "Platform", Type: "string", Description: "Image platform"},
+	}
+}
+
+// imageMetadataTableRowCells returns the common table row cells for resources that
+// implement the ImageMetadataAccessor interface.
+func imageMetadataTableRowCells(name string, obj v1alpha1.ImageMetadataAccessor) []interface{} {
+	meta := obj.GetImageMetadata()
+
+	reference := fmt.Sprintf("%s/%s:%s", meta.RegistryURI, meta.Repository, meta.Tag)
+
+	return []interface{}{
+		name,
+		reference,
+		meta.Platform,
+	}
+}

--- a/internal/storage/vulnerabilityreport_store.go
+++ b/internal/storage/vulnerabilityreport_store.go
@@ -1,16 +1,17 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/rancher/sbombastic/api/storage/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
-	"k8s.io/apiserver/pkg/registry/rest"
 )
 
 const CreateVulnerabilityReportTableSQL = `
@@ -54,9 +55,7 @@ func NewVulnerabilityReport(
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,
 		DeleteStrategy: strategy,
-
-		// TODO: define table converter that exposes more than name/creation timestamp
-		TableConvertor: rest.NewDefaultTableConvertor(v1alpha1.Resource("vulnerabilityreports")),
+		TableConvertor: &vulnerabilityReportTableConvertor{},
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: getAttrs}
@@ -65,4 +64,43 @@ func NewVulnerabilityReport(
 	}
 
 	return store, nil
+}
+
+type vulnerabilityReportTableConvertor struct{}
+
+func (c *vulnerabilityReportTableConvertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1.Table, error) {
+	columns := append(
+		imageMetadataTableColumns(),
+		metav1.TableColumnDefinition{Name: "Summary", Type: "string", Description: "Summary"},
+	)
+
+	table := &metav1.Table{
+		ColumnDefinitions: columns,
+		Rows:              []metav1.TableRow{},
+	}
+
+	// Handle both single object and list
+	var reports []v1alpha1.VulnerabilityReport
+	switch t := obj.(type) {
+	case *v1alpha1.VulnerabilityReportList:
+		reports = t.Items
+	case *v1alpha1.VulnerabilityReport:
+		reports = []v1alpha1.VulnerabilityReport{*t}
+	default:
+		return nil, fmt.Errorf("unexpected type %T", obj)
+	}
+
+	for _, report := range reports {
+		cells := append(
+			imageMetadataTableRowCells(report.Name, &report),
+			"TODO",
+		)
+		row := metav1.TableRow{
+			Object: runtime.RawExtension{Object: &report},
+			Cells:  cells,
+		}
+		table.Rows = append(table.Rows, row)
+	}
+
+	return table, nil
 }


### PR DESCRIPTION
Add custom columns to Image, SBOM and VulnerabilityReport.

The columns are shown when doing `kubectl get` and significantly improve the UX.

These are examples of the new output:

```console
☸ kind-kind in sbombastic on  main [$!?] via 🐹 v1.25.0 via  v22.15.1
❯ kubectl get registries.sbombastic.rancher.io -n sbombastic
NAME          AGE
flavio-demo   9m42s

☸ kind-kind in sbombastic on  main [$!?] via 🐹 v1.25.0 via  v22.15.1
❯ kubectl get images.storage.sbombastic.rancher.io -n sbombastic
NAME                                                               REGISTRY      REGISTRY URI   REPOSITORY                   TAG      PLATFORM      DIGEST
c1d56bc4a534720312bb221189dbe5e2e2816b9abd692c0c8764d203d943027c   flavio-demo   ghcr.io        flavio/demo/nginx-upstream   1.17.3   linux/amd64   sha256:55e7a6f2bb43e38cc34285af03b4973d61f523d26cd8a57e9d00cf4154792d20
18f9c255c496630a2e6c2cd18a5d3a49842268eec42f81dc4d9d1cd5014c9530   flavio-demo   ghcr.io        flavio/demo/nginx-upstream   1.29.1   linux/amd64   sha256:ebe6b7ee1206828d80eabed09809e94222d09fba59c7cda15da41962e06b088e

☸ kind-kind in sbombastic on  main [$!?] via 🐹 v1.25.0 via  v22.15.1
❯ kubectl get sboms.storage.sbombastic.rancher.io -n sbombastic
NAME                                                               REGISTRY      REGISTRY URI   REPOSITORY                   TAG      PLATFORM      DIGEST
c1d56bc4a534720312bb221189dbe5e2e2816b9abd692c0c8764d203d943027c   flavio-demo   ghcr.io        flavio/demo/nginx-upstream   1.17.3   linux/amd64   sha256:55e7a6f2bb43e38cc34285af03b4973d61f523d26cd8a57e9d00cf4154792d20
18f9c255c496630a2e6c2cd18a5d3a49842268eec42f81dc4d9d1cd5014c9530   flavio-demo   ghcr.io        flavio/demo/nginx-upstream   1.29.1   linux/amd64   sha256:ebe6b7ee1206828d80eabed09809e94222d09fba59c7cda15da41962e06b088e

☸ kind-kind in sbombastic on  main [$!?] via 🐹 v1.25.0 via  v22.15.1
❯ kubectl get vulnerabilityreports.storage.sbombastic.rancher.io -n sbombastic
NAME                                                               REGISTRY      REGISTRY URI   REPOSITORY                   TAG      PLATFORM      DIGEST
c1d56bc4a534720312bb221189dbe5e2e2816b9abd692c0c8764d203d943027c   flavio-demo   ghcr.io        flavio/demo/nginx-upstream   1.17.3   linux/amd64   sha256:55e7a6f2bb43e38cc34285af03b4973d61f523d26cd8a57e9d00cf4154792d20
18f9c255c496630a2e6c2cd18a5d3a49842268eec42f81dc4d9d1cd5014c9530   flavio-demo   ghcr.io        flavio/demo/nginx-upstream   1.29.1   linux/amd64   sha256:ebe6b7ee1206828d80eabed09809e94222d09fba59c7cda15da41962e06b088e
```
