### PR TITLE
fix(ci): code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: E2E test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rancher-sandbox/sbombastic/security/code-scanning/8](https://github.com/rancher-sandbox/sbombastic/security/code-scanning/8)

To fix the issue, add a `permissions:` block granting only the minimum privileges necessary. Since the workflow jobs only check out source code and upload artifacts (and are not making changes to the repo or issues/pull requests), the minimal required permission is `contents: read`. This can be set either at the workflow level (before `jobs:`) to apply to all jobs, or at the job level (under `test:`) if fine-tuning is needed. In this case, adding it at the root just below `name:` and above `on:` ensures maximum coverage and is the simplest solution. No additional libraries or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
