### PR TITLE
test(e2e): test ScanJob cascade deletion when a Registry is deleted

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -191,6 +191,14 @@ func TestRegistryCreation(t *testing.T) {
 			require.NoError(t, err)
 			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceDeleted(registry))
 			require.NoError(t, err)
+			// Verify the ScanJob is deleted
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceDeleted(&v1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scanjob",
+					Namespace: cfg.Namespace(),
+				},
+			}))
+			require.NoError(t, err)
 
 			return ctx
 		}).


### PR DESCRIPTION
## Description

Add test assertion to e2e tests: ScanJob cascade deletion when a Registry is deleted