### PR TITLE
feat(storage): TLS and auto-reload of certificates

### DIFF
--- a/charts/sbombastic/templates/storage/apiservice.yaml
+++ b/charts/sbombastic/templates/storage/apiservice.yaml
@@ -2,11 +2,12 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.storage.sbombastic.rancher.io
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "sbombastic.fullname" . }}-storage-tls
   labels:
     {{ include "sbombastic.labels" .| nindent 4 }}
     app.kubernetes.io/component: storage
 spec:
-  insecureSkipTLSVerify: true
   group: storage.sbombastic.rancher.io
   groupPriorityMinimum: 1000
   versionPriority: 15

--- a/charts/sbombastic/templates/storage/cert-manager.yaml
+++ b/charts/sbombastic/templates/storage/cert-manager.yaml
@@ -1,0 +1,27 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-storage-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storage
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "sbombastic.fullname" . }}-storage-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sbombastic.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storage
+spec:
+  secretName: {{ include "sbombastic.fullname" . }}-storage-tls
+  dnsNames:
+    - {{ include "sbombastic.fullname" . }}-storage.{{ .Release.Namespace }}.svc
+    - {{ include "sbombastic.fullname" . }}-storage.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "sbombastic.fullname" . }}-storage-issuer

--- a/charts/sbombastic/templates/storage/deployment.yaml
+++ b/charts/sbombastic/templates/storage/deployment.yaml
@@ -35,8 +35,8 @@ spec:
 {{ toYaml .Values.storage.resources | indent 12 }}
           {{- end }}
           volumeMounts:
-            - name: cert-volume
-              mountPath: /certs
+            - name: storage-tls
+              mountPath: /tls
             - name: pg-secret
               mountPath: /pg
               readOnly: true
@@ -44,8 +44,9 @@ spec:
               mountPath: /pg/tls/server/
               readOnly: true
       volumes:
-        - name: cert-volume
-          emptyDir: {}
+        - name: storage-tls
+          secret:
+            secretName: {{ include "sbombastic.fullname" . }}-storage-tls
         - name: pg-secret
           secret:
             {{- if .Values.storage.postgres.cnpg.enabled }}
@@ -63,4 +64,5 @@ spec:
             items:
             - key: ca.crt
               path: ca.crt
+
 


### PR DESCRIPTION
## Description
This PR adds TLS certificate generation via cert-manager to the storage component.

It also configures automatic certificate reloading using the apiserver's [`DynamicCertKeyPairContent`](https://pkg.go.dev/k8s.io/apiserver/pkg/server/dynamiccertificates) utility, which uses fsnotify under the hood to watch for certificate file changes.

Fixes #241 