### PR TITLE
fix(Tiltfile): wrong cnpg repo name

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -53,7 +53,7 @@ helm_resource(
 
 
 # Install CloudNativePG
-helm_repo("cnpg-repo", "https://cloudnative-pg.github.io/charts")
+helm_repo("cnpg", "https://cloudnative-pg.github.io/charts")
 helm_resource(
     "cloudnativepg",
     "cnpg/cloudnative-pg",
@@ -62,7 +62,7 @@ helm_resource(
         "--create-namespace",
     ],
     resource_deps=[
-        "cnpg-repo",
+        "cnpg",
     ],
 )
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
The cnpg repo name was wrong in the `Tiltfile`. This PR fix it.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
