### PR TITLE
chore: notify kubewarden/helm-charts about release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,9 +117,15 @@ jobs:
           - kubewarden/helm-charts
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.WORKFLOW_PAT }}
+          token: ${{ steps.generate-token.output.token }}
           repository: ${{ matrix.repo }}
           event-type: release-sbomscanner


### PR DESCRIPTION
## Description

Related to https://github.com/kubewarden/helm-charts/pull/805

Improve the release script to send a release event "release-sbomscanner" to the GitHub repository https://github.com/kubewarden/helm-charts

The goal is to trigger this Updatecli workflow https://github.com/kubewarden/helm-charts/pull/805

## Test

I didn't test this PR yet, as I don't know what Token to use for the GitHub workflow.
The secrets "WORKFLOW_PAT" seems available, but I don't know if it has enough permission.

More information on the required permission on [peter-evans/repository-dispatch](https://github.com/peter-evans/repository-dispatch?tab=readme-ov-file#token)

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

A GitHub Token can run out of API request limit if used too much which is not something we want to deal with, in the middle of a release, so I would be in favor of using a dedicated GitHub for releases 