### PR TITLE
chore: update SBOMscanner helm chart automation

### DIFF
--- a/updatecli/updatecli.release.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.release.d/helm-chart-update.yaml
@@ -5,7 +5,7 @@ sources:
     name: "Get latest sbomscanner helm version"
     kind: yaml
     transformers:
-      - semverinc: patch
+      - semverinc: minor
     spec:
       file: charts/sbomscanner/Chart.yaml
       key: $.version
@@ -36,8 +36,9 @@ scms:
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
       commitmessage:
+        squash: true
         type: "chore"
-        title: "Update SBOMscanner Helm charts"
+        title: "update SBOMscanner Helm charts"
         hidecredit: true
         footers: "Signed-off-by: SBOMscanner bot <sbomscanner-bot@users.noreply.github.com>"
 
@@ -98,4 +99,3 @@ targets:
     spec:
       file: charts/sbomscanner/values.yaml
       key: $.worker.image.tag
-


### PR DESCRIPTION
## Description

* Squash all commits created by Updatecli
* Lower case commit title to be conventional commit compliant
* By default, bump the chart version to the next minor

## Test

I didn't test this change, but normally everything should be fine

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
