### PR TITLE
fix(handlers): JAVA db is required when generating SBOMs

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -110,7 +110,7 @@ func main() { //nolint:funlen // This function is intentionally long to keep the
 
 	registry := messaging.HandlerRegistry{
 		handlers.CreateCatalogSubject: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, publisher, logger),
-		handlers.GenerateSBOMSubject:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, runDir, publisher, logger),
+		handlers.GenerateSBOMSubject:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, runDir, trivyJavaDBRepository, publisher, logger),
 		handlers.ScanSBOMSubject:      handlers.NewScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, logger),
 	}
 	failureHandler := handlers.NewScanJobFailureHandler(k8sClient, logger)

--- a/internal/handlers/generate_sbom_test.go
+++ b/internal/handlers/generate_sbom_test.go
@@ -161,7 +161,7 @@ func testGenerateSBOM(t *testing.T, platform, sha256, expectedSPDXJSON string) {
 		expectedScanMessage,
 	).Return(nil).Once()
 
-	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", publisher, slog.Default())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, slog.Default())
 
 	message, err := json.Marshal(&GenerateSBOMMessage{
 		BaseMessage: BaseMessage{
@@ -297,7 +297,7 @@ func TestGenerateSBOMHandler_Handle_StopProcessing(t *testing.T) {
 			publisher := messagingMocks.NewMockPublisher(t)
 			// Publisher should not be called since we exit early
 
-			handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", publisher, slog.Default())
+			handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, slog.Default())
 
 			message, err := json.Marshal(&GenerateSBOMMessage{
 				BaseMessage: BaseMessage{
@@ -415,7 +415,7 @@ func TestGenerateSBOMHandler_Handle_ExistingSBOM(t *testing.T) {
 		expectedScanMessage,
 	).Return(nil).Once()
 
-	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", publisher, slog.Default())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, slog.Default())
 
 	message, err := json.Marshal(&GenerateSBOMMessage{
 		BaseMessage: BaseMessage{
@@ -539,7 +539,7 @@ func TestGenerateSBOMHandler_Handle_PrivateRegistry(t *testing.T) {
 		expectedScanMessage,
 	).Return(nil).Once()
 
-	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", publisher, slog.Default())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, slog.Default())
 
 	message, err := json.Marshal(&GenerateSBOMMessage{
 		BaseMessage: BaseMessage{

--- a/internal/handlers/scan_sbom.go
+++ b/internal/handlers/scan_sbom.go
@@ -161,8 +161,6 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message messaging.Message)
 		"--disable-telemetry",
 		"--cache-dir", h.workDir,
 		"--format", "json",
-		// Use the public ECR repository to bypass GitHub's rate limits.
-		// Refer to https://github.com/orgs/community/discussions/139074 for details.
 		"--db-repository", h.trivyDBRepository,
 		"--java-db-repository", h.trivyJavaDBRepository,
 		"--output", reportFile.Name(),

--- a/internal/handlers/scan_sbom_test.go
+++ b/internal/handlers/scan_sbom_test.go
@@ -25,11 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-const (
-	testTrivyDBRepository     = "ghcr.io/kubewarden/sbomscanner/test-assets/trivy-db:2"
-	testTrivyJavaDBRepository = "ghcr.io/kubewarden/sbomscanner/test-assets/trivy-java-db:2"
-)
-
 func TestScanSBOMHandler_Handle(t *testing.T) {
 	vexHubServer := fakeVEXHubRepository(t)
 	vexHubServer.Start()

--- a/internal/handlers/utils_test.go
+++ b/internal/handlers/utils_test.go
@@ -13,6 +13,11 @@ import (
 )
 
 const (
+	testTrivyDBRepository     = "ghcr.io/kubewarden/sbomscanner/test-assets/trivy-db:2"
+	testTrivyJavaDBRepository = "ghcr.io/kubewarden/sbomscanner/test-assets/trivy-java-db:2"
+)
+
+const (
 	registryPort = "5000/tcp"
 	authUser     = "user"
 	authPass     = "password"


### PR DESCRIPTION
## Description

The Java DB is required to generate SBOMs for images containing Java components, so it cannot be skipped.

See: https://github.com/aquasecurity/trivy/discussions/9666