### PR TITLE
fix: typo in quickstart guide for ScanJob

### DIFF
--- a/docs/installation/quickstart.md
+++ b/docs/installation/quickstart.md
@@ -143,7 +143,7 @@ spec:
 ### Create a ScanJob CR
 
 ```bash
-kubectl apply -f scan-job.yaml
+kubectl apply -f scanjob.yaml
 ```
 
 ### Wait for Results


### PR DESCRIPTION
## Description

This PR fixes just a small issue in the scan job section.
