### PR TITLE
ci: change how the docker buildx is invoked

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -53,8 +53,6 @@ jobs:
           sbom: true
           provenance: mode=max
           tags: ghcr.io/${{ github.repository_owner }}/sbomscanner/${{ matrix.component }}
-          outputs: |
-            type=image,push=true,push-by-digest=true,name-canonical=true
       - name: Export digest
         run: |
           mkdir -p ${{ runner.temp }}/digests


### PR DESCRIPTION
We currently have a problem with docker buildx not pushing attestations
to the OCI registry.

Comparing this automation with the one of other KW components, this line
is not present.
