### PR TITLE
ci: fix attestation generation

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -68,41 +68,44 @@ jobs:
                         | select(.annotations["in-toto.io/predicate-type"] == "https://slsa.dev/provenance/v0.2")
                         | .digest')
           echo "PROVENANCE_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
-      - name: Sign provenance manifest
-        run: |
-          cosign sign --yes \
-          ghcr.io/${{github.repository_owner}}/sbomscanner/${{ inputs.component }}@${{ env.PROVENANCE_DIGEST}}
-          cosign verify \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-            --certificate-identity="https://github.com/${{github.repository_owner}}/sbomscanner/.github/workflows/attestation.yml@${{ github.ref }}" \
-            ghcr.io/${{github.repository_owner}}/sbomscanner/${{ inputs.component }}@${{ env.PROVENANCE_DIGEST}}
       - name: Find SBOM manifest layer digest
         run: |
           set -e
           DIGEST=$(crane manifest ghcr.io/${{github.repository_owner}}/sbomscanner/${{ inputs.component }}@${{ env.ATTESTATION_MANIFEST_DIGEST}} |  \
             jq '.layers | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")) | map(.digest) | join(" ")')
           echo "SBOM_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
+
+      # We need to upload provenance and SBOM files, plus their signatures under the GitHub Release page.
+      # Moreover, the files have to be named in a certain way.
+      # This is required by [ossf](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases)
       - name: Download provenance and SBOM files
         run: |
           set -e
           crane blob ghcr.io/${{github.repository_owner}}/sbomscanner/${{ inputs.component }}@${{ env.PROVENANCE_DIGEST}} \
-            > SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-provenance.json
-          sha256sum SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-provenance.json \
-            >> SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-checksum.txt
+            > SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-provenance.intoto.jsonl
           crane blob ghcr.io/${{github.repository_owner}}/sbomscanner/${{ inputs.component }}@${{ env.SBOM_DIGEST}} \
             > SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-sbom.json
-          sha256sum SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-sbom.json \
-            >> SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-checksum.txt
-      - name: Sign checksum file
+      - name: Sign provenance and SBOM files
         run: |
+          set -e
           cosign sign-blob --yes \
-            --bundle SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-checksum-cosign.bundle \
-            SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-checksum.txt
+            --bundle SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-provenance.intoto.jsonl.bundle.sigstore \
+            SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-provenance.intoto.jsonl
           cosign verify-blob \
-            --bundle SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-checksum-cosign.bundle \
+            --bundle SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-provenance.intoto.jsonl.bundle.sigstore \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
             --certificate-identity="https://github.com/${{github.repository_owner}}/sbomscanner/.github/workflows/attestation.yml@${{ github.ref }}" \
-            SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-checksum.txt
+            SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-provenance.intoto.jsonl
+
+          cosign sign-blob --yes \
+            --bundle SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-sbom.json.bundle.sigstore \
+            SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-sbom.json
+          cosign verify-blob \
+            --bundle SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-sbom.json.bundle.sigstore \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity="https://github.com/${{github.repository_owner}}/sbomscanner/.github/workflows/attestation.yml@${{ github.ref }}" \
+            SBOMscanner-${{ inputs.component }}-attestation-${{ inputs.arch }}-sbom.json
+
       - name: Upload SBOMs as artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,6 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
 
-      - name: Create tarball for the attestation files
-        run: |
-          for arch in "amd64" "arm64"; do
-            for component in "controller" "worker" "storage"; do
-              tar -czf attestation-SBOMscanner-$component-$arch.tar.gz $(ls SBOMscanner-$component-attestation-$arch-*)
-            done
-          done
       - name: Upload release assets
         id: upload_release_assets
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -63,12 +56,32 @@ jobs:
             let fs = require('fs');
             let path = require('path');
             let files = [
-                'attestation-SBOMscanner-controller-amd64.tar.gz',
-                'attestation-SBOMscanner-worker-amd64.tar.gz',
-                'attestation-SBOMscanner-storage-amd64.tar.gz',
-                'attestation-SBOMscanner-controller-arm64.tar.gz',
-                'attestation-SBOMscanner-worker-arm64.tar.gz',
-                'attestation-SBOMscanner-storage-arm64.tar.gz',
+                'SBOMscanner-controller-attestation-amd64-provenance.intoto.jsonl',
+                'SBOMscanner-controller-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
+                'SBOMscanner-controller-attestation-arm64-provenance.intoto.jsonl',
+                'SBOMscanner-controller-attestation-arm64-provenance.intoto.jsonl.bundle.sigstore',
+                'SBOMscanner-controller-attestation-amd64-sbom.json',
+                'SBOMscanner-controller-attestation-amd64-sbom.json.bundle.sigstore',
+                'SBOMscanner-controller-attestation-arm64-sbom.json',
+                'SBOMscanner-controller-attestation-arm64-sbom.json.bundle.sigstore',
+
+                'SBOMscanner-worker-attestation-amd64-provenance.intoto.jsonl',
+                'SBOMscanner-worker-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
+                'SBOMscanner-worker-attestation-arm64-provenance.intoto.jsonl',
+                'SBOMscanner-worker-attestation-arm64-provenance.intoto.jsonl.bundle.sigstore',
+                'SBOMscanner-worker-attestation-amd64-sbom.json',
+                'SBOMscanner-worker-attestation-amd64-sbom.json.bundle.sigstore',
+                'SBOMscanner-worker-attestation-arm64-sbom.json',
+                'SBOMscanner-worker-attestation-arm64-sbom.json.bundle.sigstore',
+
+                'SBOMscanner-storage-attestation-amd64-provenance.intoto.jsonl',
+                'SBOMscanner-storage-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
+                'SBOMscanner-storage-attestation-arm64-provenance.intoto.jsonl',
+                'SBOMscanner-storage-attestation-arm64-provenance.intoto.jsonl.bundle.sigstore',
+                'SBOMscanner-storage-attestation-amd64-sbom.json',
+                'SBOMscanner-storage-attestation-amd64-sbom.json.bundle.sigstore',
+                'SBOMscanner-storage-attestation-arm64-sbom.json',
+                'SBOMscanner-storage-attestation-arm64-sbom.json.bundle.sigstore',
                 ]
             const {RELEASE_ID} = process.env
             for (const file of files) {


### PR DESCRIPTION
Release was broken because we've moved to cosign v3 as a result of updating to the latest release of cosign-installer GHA.

As opposed to v2, cosign v3 fails when we attempt to sign the attestation generated by docker buildx. That's because docker buildx pushes the attestations as blobs inside of the OCI registry.
When we invoke `cosign sign` using v3, the code attempts to find a `manifest`, and rightfully fails (there's no manifest at that location, just a blob).

That lead us to revisit why we were signing the attestation blob. It turns out we don't need to do that, since the attestation blob is part of the OCI index that is already signed by cosign.

We still need to upload the attestation and its signature to the GitHub Release as assets. That's one of the requirements of openssf.

While fixing the code, we also realized the assets need to be named in a different way to match the openssf checks. That's why, inside of this PR, we do no longer bundle them inside of an archive.

You can see a full run [here](https://github.com/flavio/sbomscanner/actions/runs/18687977752), and its resulting [release here](https://github.com/flavio/sbomscanner/releases/tag/v0.7.2-flavio).
