### PR TITLE
feat(handlers): reuse SBOM with the same sha instead of generating it

### DIFF
--- a/api/storage/v1alpha1/image_metadata.go
+++ b/api/storage/v1alpha1/image_metadata.go
@@ -1,7 +1,10 @@
 package v1alpha1
 
 // IndexImageMetadataRegistry is the field index for the registry of an image.
-const IndexImageMetadataRegistry = "imageMetadata.registry"
+const (
+	IndexImageMetadataRegistry = "imageMetadata.registry"
+	IndexImageMetadataDigest   = "imageMetadata.digest"
+)
 
 // ImageMetadata contains the metadata details of an image.
 type ImageMetadata struct {


### PR DESCRIPTION
## Description

This PR optimizes the generate SBOM handler. 
Since SBOM generation can be slow (it involves network calls to pull the image), we first check for an existing SBOM with the same SHA and reuse its SPDX content. If no match is found, we fall back to generating the SBOM with Trivy as usual.
