### PR TITLE
fix(helm/storage): temporary set replicas to 1 until we support multi-instance watches.

### DIFF
--- a/charts/sbomscanner/templates/storage/deployment.yaml
+++ b/charts/sbomscanner/templates/storage/deployment.yaml
@@ -8,7 +8,10 @@ metadata:
     {{ include "sbomscanner.labels" . | nindent 4 }}
     app.kubernetes.io/component: storage
 spec:
-  replicas: {{ .Values.storage.replicas }}
+  # replicas: {{ .Values.storage.replicas }}
+  # TODO: Temporary set replicas to 1 until we support multi-instance watches
+  # see: https://github.com/kubewarden/sbomscanner/issues/628
+  replicas: 1
   selector:
     matchLabels:
       {{ include "sbomscanner.selectorLabels" . | nindent 6 }}

--- a/charts/sbomscanner/tests/storage/deployment_test.yaml
+++ b/charts/sbomscanner/tests/storage/deployment_test.yaml
@@ -10,7 +10,9 @@ tests:
         cattle:
           systemDefaultRegistry: kubewarden.io
       storage:
-        replicas: 5
+        # TODO: Temporary set replicas to 1 until we support multi-instance watches
+        # see: https://github.com/kubewarden/sbomscanner/issues/628
+        # replicas: 5
         logLevel: debug
         image:
           repository: kubewarden/sbomscanner/storage
@@ -24,9 +26,9 @@ tests:
             cpu: 250m
             memory: 200Mi
     asserts:
-      - equal:
-          path: "spec.replicas"
-          value: 5
+      # - equal:
+      #     path: "spec.replicas"
+      #     value: 5
       - equal:
           path: "spec.template.spec.containers[0].image"
           value: "kubewarden.io/kubewarden/sbomscanner/storage:v0.1.0"


### PR DESCRIPTION

Temporary set replicas to 1 until we support multi-instance watches.
See: #628 

