### PR TITLE
feat: add CEL tag evaluator

### DIFF
--- a/internal/cel/doc.go
+++ b/internal/cel/doc.go
@@ -1,0 +1,2 @@
+// Package cel contains utilities for evaluating CEL (Common Expression Language) expressions.
+package cel

--- a/internal/cel/tag.go
+++ b/internal/cel/tag.go
@@ -1,0 +1,87 @@
+package cel
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
+	"k8s.io/apiserver/pkg/cel/library"
+)
+
+// TagEvaluator is the evaluator for tag filter expressions.
+type TagEvaluator struct {
+	env *cel.Env
+}
+
+func NewTagEvaluator() (*TagEvaluator, error) {
+	env, err := cel.NewEnv(
+		cel.ASTValidators(
+			cel.ValidateDurationLiterals(),
+			cel.ValidateTimestampLiterals(),
+			cel.ValidateRegexLiterals(),
+			cel.ValidateHomogeneousAggregateLiterals(),
+		),
+		ext.Strings(),
+		library.SemverLib(library.SemverVersion(1)),
+		cel.Variable("tag", cel.StringType),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	return &TagEvaluator{
+		env: env,
+	}, nil
+}
+
+// Evaluate evaluates the given CEL expression against the provided tag.
+// Returns true if the expression evaluates to true, false otherwise.
+func (e *TagEvaluator) Evaluate(expression string, tag string) (bool, error) {
+	ast, err := e.compile(expression)
+	if err != nil {
+		return false, err
+	}
+	prg, err := e.env.Program(ast)
+	if err != nil {
+		return false, fmt.Errorf("failed to create CEL program: %w", err)
+	}
+
+	val, _, err := prg.Eval(map[string]interface{}{
+		"tag": tag,
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to evaluate expression: %w", err)
+	}
+
+	result, ok := val.Value().(bool)
+	if !ok {
+		return false, errors.New("expression did not evaluate to a boolean")
+	}
+
+	return result, nil
+}
+
+// Validate validates the given CEL expression against the tag evaluator's environment.
+// Returns an error if the expression is invalid or does not evaluate to a boolean.
+func (e *TagEvaluator) Validate(expression string) error {
+	ast, err := e.compile(expression)
+	if err != nil {
+		return err
+	}
+
+	if ast.OutputType() != cel.BoolType {
+		return errors.New("must evaluate to bool")
+	}
+
+	return nil
+}
+
+func (e *TagEvaluator) compile(expression string) (*cel.Ast, error) {
+	ast, issues := e.env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("failed to compile expression: %w", issues.Err())
+	}
+
+	return ast, nil
+}

--- a/internal/cel/tag_test.go
+++ b/internal/cel/tag_test.go
@@ -1,0 +1,89 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTagEvaluator_Evaluate(t *testing.T) {
+	evaluator, err := NewTagEvaluator()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		expression     string
+		tag            string
+		expectedResult bool
+		expectedErr    bool
+	}{
+		{
+			name:           "expression with semver",
+			expression:     "semver(tag, true).isLessThan(semver('v1.0.0-dev', true))",
+			tag:            "v0.9.0",
+			expectedResult: true,
+		},
+		{
+			name:           "expression wiht regex",
+			expression:     "tag.matches('alpine$')",
+			tag:            "v1.12.1-alpine",
+			expectedResult: true,
+		},
+		{
+			name:           "expression with string comparison",
+			expression:     "tag == 'v.1.0.0'",
+			tag:            "latest",
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := evaluator.Evaluate(test.expression, test.tag)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestTagEvaluator_Validate(t *testing.T) {
+	tagEvaluator, err := NewTagEvaluator()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		expression  string
+		expectedErr string
+	}{
+		{
+			name:       "valid expression",
+			expression: "semver(tag, true).isLessThan(semver('v1.0.0-dev', true))",
+		},
+		{
+			name:        "unknown variable",
+			expression:  "unknown_var == 'value'",
+			expectedErr: "undeclared reference to 'unknown_var'",
+		},
+		{
+			name:        "return type is not boolean",
+			expression:  "tag + 'suffix'",
+			expectedErr: "must evaluate to bool",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := tagEvaluator.Validate(test.expression)
+			if test.expectedErr != "" {
+				require.ErrorContains(t, err, test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Introduce a CEL-based tag evaluator that filters tags using CEL expressions, extended with Kubernetes’ [semver CEL library](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-semver-library).

Note: Regular expressions are built into CEL and can be applied using `<string>.matches`.

Part of: #460 