### PR TITLE
ci(helm): disable helm-unittest plugin verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Install helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      # Disable plugin verification until the following issue is addressed https://github.com/helm-unittest/helm-unittest/issues/777
       - name: Install Helm-unittest
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
       - run: make helm-unittest
 
   golangci:


### PR DESCRIPTION


## Description

Disable helm-unittest plugin verification, needed by helm v4,  but not yet supported by the plugin.

Fixes to #658 

Related to https://github.com/helm-unittest/helm-unittest/issues/777

