### PR TITLE
perf(controller): watch only VulnerabilityReport metadata instead of the full object

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -26,10 +26,12 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/nats-io/nats.go"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -232,8 +234,15 @@ func main() {
 				&storagev1alpha1.Image{}: {
 					Transform: storage.TransformStripImage,
 				},
-				&storagev1alpha1.VulnerabilityReport{}: {
-					Transform: storage.TransformStripVulnerabilityReport,
+				&metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: storagev1alpha1.SchemeGroupVersion.String(),
+						Kind:       "VulnerabilityReport",
+					},
+				}: {
+					Transform: cache.TransformStripManagedFields(),
+					// Metadata-only watch, skip deep copy since we treat it as read-only.
+					UnsafeDisableDeepCopy: ptr.To(true),
 				},
 			},
 		},

--- a/internal/controller/vulnerabilityreport_controller.go
+++ b/internal/controller/vulnerabilityreport_controller.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -27,7 +28,10 @@ type VulnerabilityReportReconciler struct {
 func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	vulnerabilityReport := &storagev1alpha1.VulnerabilityReport{}
+	// Fetch only metadata to reduce memory usage and API server load.
+	vulnerabilityReport := &metav1.PartialObjectMetadata{}
+	vulnerabilityReport.SetGroupVersionKind(storagev1alpha1.SchemeGroupVersion.WithKind("VulnerabilityReport"))
+
 	if err := r.Get(ctx, req.NamespacedName, vulnerabilityReport); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, fmt.Errorf("unable to fetch the VulnerabilityReport: %w", err)
@@ -58,7 +62,9 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	scanJob := &scanJobs.Items[0]
 
-	vulnerabilityReports := &storagev1alpha1.VulnerabilityReportList{}
+	// Fetch only metadata to reduce memory usage and API server load.
+	vulnerabilityReports := &metav1.PartialObjectMetadataList{}
+	vulnerabilityReports.SetGroupVersionKind(storagev1alpha1.SchemeGroupVersion.WithKind("VulnerabilityReportList"))
 	if err := r.List(ctx, vulnerabilityReports,
 		client.InNamespace(req.Namespace),
 		client.MatchingLabels{v1alpha1.LabelScanJobUIDKey: scanJobUID},
@@ -93,7 +99,8 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
-		For(&storagev1alpha1.VulnerabilityReport{}).
+		// Watch only metadata to reduce memory usage and API server load.
+		For(&storagev1alpha1.VulnerabilityReport{}, builder.OnlyMetadata).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("failed to create VulnerabilityReport controller: %w", err)


### PR DESCRIPTION
## Description

Switch VulnerabilityReport controller to metadata-only watch. We only need labels and deletion timestamp, not the full spec/status with all the vulnerability data.

This drops memory usage significantly at startup with existing VulnerabilityReports:

| Implementation | Memory (1000 VulnerabilityReports) |
|----------------|-------------------------------------|
| No optimization | ~1002Mi |
| Cache transform | ~825Mi |
| Metadata watch (this PR) | ~317Mi |

The controller now uses `PartialObjectMetadata` for Get/List operations and configures the cache with `UnsafeDisableDeepCopy` since we treat the objects as read-only.
