### PR TITLE
ci: temporarily pin helm-unittest to v1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,9 @@ jobs:
       - name: Install helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       # Disable plugin verification until the following issue is addressed https://github.com/helm-unittest/helm-unittest/issues/777
+      # Pin to v1.0.2 until https://github.com/helm-unittest/helm-unittest/issues/790 is resolved
       - name: Install Helm-unittest
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false --version v1.0.2
       - run: make helm-unittest
 
   golangci:


### PR DESCRIPTION
## Description

Temporarily pin helm-unittest to v1.0.2 to fix CI failures due to https://github.com/helm-unittest/helm-unittest/issues/790

