### PR TITLE
fix(helm): set cnpg cluster storageclass only if not blank or nil

### DIFF
--- a/charts/sbomscanner/templates/storage/cnpg.yaml
+++ b/charts/sbomscanner/templates/storage/cnpg.yaml
@@ -9,6 +9,8 @@ spec:
   storage:
     size: {{ .Values.storage.postgres.cnpg.storage.size }}
     resizeInUseVolumes: {{ .Values.storage.postgres.cnpg.storage.resizeInUseVolumes }}
+    {{- if .Values.storage.postgres.cnpg.storage.storageClass }}
     storageClass: {{ .Values.storage.postgres.cnpg.storage.storageClass }}
+    {{- end }}
     pvcTemplate: {{ .Values.storage.postgres.cnpg.storage.pvcTemplate | toYaml | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
This pull request makes a small improvement to the `charts/sbomscanner/templates/storage/cnpg.yaml` Helm template. The change ensures that the `storageClass` field is only included in the generated YAML if it has been set in the values file, preventing the field from being rendered with an empty value.

* Conditional rendering of the `storageClass` field in the storage configuration to avoid empty values in the generated YAML (`charts/sbomscanner/templates/storage/cnpg.yaml`).