### PR TITLE
ci: update workflows for self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: CI
 
 on:
   workflow_call:
-  push:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -11,14 +14,19 @@ permissions: read-all
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
+          cache: false
           go-version-file: "go.mod"
-      - uses: ./.github/actions/free-up-disk-space
       - run: make test
+        env:
+          # Fixes issue with selinux
+          TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED: true
+          # Fixes issue with runner cleanup
+          ENVTEST_DIR: /home/runner/.cache/envtest
       - name: Upload unit-tests coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
@@ -38,6 +46,7 @@ jobs:
       # Disable plugin verification until the following issue is addressed https://github.com/helm-unittest/helm-unittest/issues/777
       - name: Install Helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
+
       - run: make helm-unittest
 
   golangci:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,16 +5,20 @@ permissions:
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run E2E tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
+          cache: false
           go-version-file: "go.mod"
-      - uses: ./.github/actions/free-up-disk-space
       - name: Run e2e tests
         run: make test-e2e
       - name: Upload cluster logs


### PR DESCRIPTION
## Description

Workflow modifications required for switch to self-hosted runners.
We will have 3 github runners, 60GB disk, 4CPUs, 18GB RAM each

To test changes I created [20 PRs in my fork](https://github.com/kravciak/sbomscanner/pulls) and X of them passed.

## Todo
- [x] <b>VM host will be transfered to data center in February, we are postponing switch until then</b>
- [x] Check that docker images:latest are not reused (we don't test old latest tag)
- [x] Failed to create credential store from DOCKER_AUTH_CONFIG:  json: unknown field "username"
- [x] some jobs can use github official runners (helm-test, ...)
- [ ] runners are eating disk space, go cache, docker dangling images?

## Changes

- TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED:
Fixes issues with selinux
https://golang.testcontainers.org/features/configuration/#customizing-ryuk-the-resource-reaper

- ENVTEST_DIR:
Fixes issue with runner cleanup

- Slow cache deployment:
cache: false

- concurrency:
cancel previous jobs

- helm plugin:
can't install existing plugin

- removed free-up-disk-space calls