### PR TITLE
fix(controller): skip VulnerabilityReport reconciliation for completed ScanJobs

### DIFF
--- a/internal/controller/vulnerabilityreport_controller.go
+++ b/internal/controller/vulnerabilityreport_controller.go
@@ -62,6 +62,13 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	scanJob := &scanJobs.Items[0]
 
+	// If the ScanJob is already complete, there's no need to update its status again.
+	if scanJob.IsComplete() {
+		log.V(1).Info("ScanJob is already complete, skipping status update",
+			"scanJob", scanJob.Name)
+		return ctrl.Result{}, nil
+	}
+
 	// Fetch only metadata to reduce memory usage and API server load.
 	vulnerabilityReports := &metav1.PartialObjectMetadataList{}
 	vulnerabilityReports.SetGroupVersionKind(storagev1alpha1.SchemeGroupVersion.WithKind("VulnerabilityReportList"))

--- a/internal/controller/vulnerabilityreport_controller_test.go
+++ b/internal/controller/vulnerabilityreport_controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/smithy-go/ptr"
 	. "github.com/onsi/ginkgo/v2"
@@ -172,6 +173,70 @@ var _ = Describe("VulnerabilityReport Controller", func() {
 				},
 			),
 		)
+	})
+
+	When("a ScanJob is already complete", func() {
+		It("should skip reconciliation and not update CompletionTime", func(ctx context.Context) {
+			By("Creating a ScanJob that is already complete")
+			scanJob := &v1alpha1.ScanJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scanjob-complete-" + uuid.New().String()[:8],
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ScanJobSpec{
+					Registry: "test-registry",
+				},
+			}
+			Expect(k8sClient.Create(ctx, scanJob)).To(Succeed())
+
+			By("Marking the ScanJob as complete with a known CompletionTime")
+			originalCompletionTime := metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+			scanJob.Status.ImagesCount = 2
+			scanJob.Status.ScannedImagesCount = 2
+			scanJob.Status.CompletionTime = &originalCompletionTime
+			scanJob.MarkComplete(v1alpha1.ReasonAllImagesScanned, "All images scanned successfully")
+			// MarkComplete overwrites CompletionTime, so set it back to our known value
+			scanJob.Status.CompletionTime = &originalCompletionTime
+			Expect(k8sClient.Status().Update(ctx, scanJob)).To(Succeed())
+
+			By("Creating a VulnerabilityReport referencing the complete ScanJob")
+			vulnerabilityReport := storagev1alpha1.VulnerabilityReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      uuid.New().String(),
+					Namespace: "default",
+					Labels: map[string]string{
+						v1alpha1.LabelScanJobUIDKey: string(scanJob.UID),
+					},
+				},
+				Report: storagev1alpha1.Report{
+					Results: []storagev1alpha1.Result{},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &vulnerabilityReport)).To(Succeed())
+
+			By("Reconciling the VulnerabilityReport")
+			reconciler := VulnerabilityReportReconciler{
+				Client: mgrClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vulnerabilityReport.Name,
+					Namespace: vulnerabilityReport.Namespace,
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			By("Verifying that CompletionTime was not modified")
+			updatedScanJob := &v1alpha1.ScanJob{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      scanJob.Name,
+				Namespace: scanJob.Namespace,
+			}, updatedScanJob)).To(Succeed())
+			Expect(updatedScanJob.IsComplete()).To(BeTrue())
+			Expect(updatedScanJob.Status.CompletionTime.Time.UTC()).To(Equal(originalCompletionTime.Time.UTC()))
+		})
 	})
 
 	Describe("VulnerabilityReports are reconciled with invalid ScanJob references", func() {


### PR DESCRIPTION
## Description

The VulnerabilityReport reconciler was unconditionally updating the ScanJob status on every reconcile, resetting CompletionTime to thecurrent time even when the ScanJob was already complete. 

This causedtwo issues:

- CompletionTime kept drifting forward, preventing the RegistryScanRunner from ever seeing the scan interval as elapsed,  so new scans were never scheduled.
- The status update bumped the resourceVersion, causing concurrentreconciles for other VulnerabilityReports of the same ScanJob to hit optimistic concurrency conflicts and enter a long retry loop.

Add an early return when the ScanJob is already complete, making the reconciler a no-op for terminal ScanJobs.

Closes #590