### PR TITLE
docs: restore vexhub repo example

### DIFF
--- a/docs/user-guide/vex.md
+++ b/docs/user-guide/vex.md
@@ -24,7 +24,7 @@ kind: VEXHub
 metadata:
   name: kubewarden
 spec:
-  url: "https://github.com/kubewarden/vexhub"
+  url: "https://github.com/rancher/vexhub"
   enabled: true
 ```
 


### PR DESCRIPTION
## Description

Restore vexhub repo example that was changed during the project rename (https://github.com/kubewarden/sbomscanner/commit/9ab7947b6ebe8cb9c371c4d31c990b13ec4d4588).

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
