### PR TITLE
fix(helm): nats securitycontext

### DIFF
--- a/charts/sbomscanner/values.schema.json
+++ b/charts/sbomscanner/values.schema.json
@@ -154,20 +154,6 @@
                                         },
                                         "readOnlyRootFilesystem": {
                                             "type": "boolean"
-                                        },
-                                        "runAsNonRoot": {
-                                            "type": "boolean"
-                                        },
-                                        "runAsUser": {
-                                            "type": "integer"
-                                        },
-                                        "seccompProfile": {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "type": "string"
-                                                }
-                                            }
                                         }
                                     }
                                 }
@@ -180,6 +166,49 @@
                     "properties": {
                         "enabled": {
                             "type": "boolean"
+                        }
+                    }
+                },
+                "podTemplate": {
+                    "type": "object",
+                    "properties": {
+                        "merge": {
+                            "type": "object",
+                            "properties": {
+                                "spec": {
+                                    "type": "object",
+                                    "properties": {
+                                        "securityContext": {
+                                            "type": "object",
+                                            "properties": {
+                                                "fsGroup": {
+                                                    "type": "integer"
+                                                },
+                                                "fsGroupChangePolicy": {
+                                                    "type": "string"
+                                                },
+                                                "runAsGroup": {
+                                                    "type": "integer"
+                                                },
+                                                "runAsNonRoot": {
+                                                    "type": "boolean"
+                                                },
+                                                "runAsUser": {
+                                                    "type": "integer"
+                                                },
+                                                "seccompProfile": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -208,20 +237,6 @@
                                         },
                                         "readOnlyRootFilesystem": {
                                             "type": "boolean"
-                                        },
-                                        "runAsNonRoot": {
-                                            "type": "boolean"
-                                        },
-                                        "runAsUser": {
-                                            "type": "integer"
-                                        },
-                                        "seccompProfile": {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "type": "string"
-                                                }
-                                            }
                                         }
                                     }
                                 }

--- a/charts/sbomscanner/values.yaml
+++ b/charts/sbomscanner/values.yaml
@@ -113,24 +113,27 @@ nats:
   container:
     merge:
       securityContext:
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 65532
-        seccompProfile:
-            type: RuntimeDefault
         allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
         capabilities:
             drop:
             - "ALL"
   reloader:
     merge:
       securityContext:
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 65532
-        seccompProfile:
-            type: RuntimeDefault
         allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
         capabilities:
             drop:
             - "ALL"
+  podTemplate:
+    merge:
+      spec:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          fsGroup: 1001
+          fsGroupChangePolicy: OnRootMismatch
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
SBOMscanner's default `nats.container.merge` and `nats.reloader.merge` overrides replace the NATS security context entirely, stripping the `fsGroup` from the pod spec.
Without `fsGroup: 1001`, Kubernetes does not chown the mounted volume to the NATS user (UID 1001) at mount time, so NATS cannot write to `/data/jetstream`.
Instead of nulling the merge (which removes all security hardening), we explicitly set the correct security context values that match what NATS expects (UID/GID 1001), and add `fsGroup: 1001` at the pod level via `podTemplate.merge`.
Fix #819 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
