### PR TITLE
fix: workloadscanconfiguration artifactsnamespace validation

### DIFF
--- a/internal/webhook/v1alpha1/workloadscanconfiguration_webhook.go
+++ b/internal/webhook/v1alpha1/workloadscanconfiguration_webhook.go
@@ -62,7 +62,7 @@ func (v *WorkloadScanConfigurationCustomValidator) ValidateUpdate(_ context.Cont
 	allErrs = append(allErrs, validateArtifactsNamespaceUpdate(
 		oldConfiguration.Spec.ArtifactsNamespace,
 		configuration.Spec.ArtifactsNamespace,
-		configuration.Spec.Enabled)...)
+		oldConfiguration.Spec.Enabled)...)
 
 	if len(allErrs) > 0 {
 		return nil, apierrors.NewInvalid(

--- a/internal/webhook/v1alpha1/workloadscanconfiguration_webhook_test.go
+++ b/internal/webhook/v1alpha1/workloadscanconfiguration_webhook_test.go
@@ -203,7 +203,28 @@ func TestWorkloadScanConfigurationCustomValidator_ValidateUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "should deny when artifactsNamespace is set while enabled",
+			name: "should allow changing artifactsNamespace and enabling in a single update",
+			oldConfiguration: &v1alpha1.WorkloadScanConfiguration{
+				Spec: v1alpha1.WorkloadScanConfigurationSpec{
+					Enabled:            false,
+					ArtifactsNamespace: "old-namespace",
+				},
+			},
+			configuration: &v1alpha1.WorkloadScanConfiguration{
+				Spec: v1alpha1.WorkloadScanConfigurationSpec{
+					Enabled:            true,
+					ArtifactsNamespace: "new-namespace",
+				},
+			},
+		},
+		{
+			name: "should deny when artifactsNamespace is changed while enabled",
+			oldConfiguration: &v1alpha1.WorkloadScanConfiguration{
+				Spec: v1alpha1.WorkloadScanConfigurationSpec{
+					Enabled:            true,
+					ArtifactsNamespace: "old-namespace",
+				},
+			},
 			configuration: &v1alpha1.WorkloadScanConfiguration{
 				Spec: v1alpha1.WorkloadScanConfigurationSpec{
 					Enabled:            true,
@@ -217,6 +238,7 @@ func TestWorkloadScanConfigurationCustomValidator_ValidateUpdate(t *testing.T) {
 			name: "should deny when artifactsNamespace is cleared while enabled",
 			oldConfiguration: &v1alpha1.WorkloadScanConfiguration{
 				Spec: v1alpha1.WorkloadScanConfigurationSpec{
+					Enabled:            true,
 					ArtifactsNamespace: "old-namespace",
 				},
 			},


### PR DESCRIPTION


* Fixed the call to `validateArtifactsNamespaceUpdate` in `workloadscanconfiguration_webhook.go` to use the old configuration's `enabled` value instead of the new one, ensuring correct validation behavior.
