### PR TITLE
fix(ci): add name to update_readme target

### DIFF
--- a/updatecli/updatecli.release.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.release.d/helm-chart-update.yaml
@@ -103,6 +103,7 @@ targets:
       key: $.worker.image.tag
   update_readme:
     scmid: default
+    name: Update Helm chart README
     kind: file
     sourceid: readmeFile
     spec:


### PR DESCRIPTION
## Description
add missing name to update_readme target, needed by the new version of updatecli