### PR TITLE
docs: add to delete CRD workloadscanconfigurations

### DIFF
--- a/docs/installation/uninstall.md
+++ b/docs/installation/uninstall.md
@@ -13,6 +13,7 @@ all the resources of these types declared inside of the cluster:
 kubectl delete crd vexhubs.sbomscanner.kubewarden.io
 kubectl delete crd scanjobs.sbomscanner.kubewarden.io
 kubectl delete crd registries.sbomscanner.kubewarden.io
+kubectl delete crd workloadscanconfigurations.sbomscanner.kubewarden.io
 ```
 
 Finally, delete the namespace where SBOMscanner was deployed:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
As workloadScan is introduced, now when uninstalling sbomscanner, CRD workloadscanconfigurations also needs to be deleted.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
