### PR TITLE
fix: avoid redundant manifest fetch for multi-arch images

### DIFF
--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -398,7 +398,7 @@ func (h *CreateCatalogHandler) refToImages(
 	}
 
 	if desc.MediaType.IsIndex() {
-		return h.multiArchRefToImages(ctx, message, registryClient, ref, registry)
+		return h.multiArchRefToImages(ctx, message, registryClient, ref, registry, desc)
 	}
 
 	return h.singleArchRefToImages(ctx, message, registryClient, ref, registry)
@@ -444,10 +444,11 @@ func (h *CreateCatalogHandler) multiArchRefToImages(
 	registryClient *registryclient.Client,
 	ref name.Reference,
 	registry *v1alpha1.Registry,
+	desc *remote.Descriptor,
 ) ([]storagev1alpha1.Image, error) {
-	imageIndex, err := registryClient.GetImageIndex(ctx, ref)
+	imageIndex, err := desc.ImageIndex()
 	if err != nil {
-		return nil, fmt.Errorf("cannot fetch image index for %q: %w", ref.Name(), err)
+		return nil, fmt.Errorf("cannot parse image index for %q: %w", ref.Name(), err)
 	}
 
 	manifest, err := imageIndex.IndexManifest()

--- a/internal/handlers/registry/client.go
+++ b/internal/handlers/registry/client.go
@@ -153,20 +153,6 @@ func (c *Client) IsContainerImage(ctx context.Context, desc *remote.Descriptor) 
 	return manifest.Config.MediaType.IsConfig(), nil
 }
 
-func (c *Client) GetImageIndex(ctx context.Context, ref name.Reference) (cranev1.ImageIndex, error) {
-	c.logger.DebugContext(ctx, "GetImageIndex called", "image", ref.Name())
-
-	index, err := remote.Index(ref,
-		remote.WithContext(ctx),
-		remote.WithAuthFromKeychain(authn.DefaultKeychain),
-		remote.WithTransport(c.transport),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("cannot fetch image index %q: %w", ref, err)
-	}
-	return index, nil
-}
-
 func (c *Client) GetImageDetails(ctx context.Context, ref name.Reference, multiArchPlatform *cranev1.Platform) (ImageDetails, error) {
 	c.logger.DebugContext(ctx, "GetImageDetails called", "image", ref.Name(), "multiArchPlatform", multiArchPlatform)
 


### PR DESCRIPTION
When processing a multi-arch image, the descriptor was already fetched via remote.Get (which sends broad Accept headers). Calling remote.Index afterwards made a second GET to the same endpoint with only index-specific Accept headers, causing some registries to return HTTP status 406.

Use desc.ImageIndex() instead, which constructs the ImageIndex from the manifest already in memory without an additional HTTP request.
