### PR TITLE
chore: require contributors to read the AI policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,3 +27,7 @@ go test
 ### Potential improvement
 
 <!-- Please describe, if any, potential improvement that you are envisioning -->
+
+## Checklist
+
+- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)


### PR DESCRIPTION
We have to make contributors aware of the AI policy, otherwise there's no point in having it :)
