### PR TITLE
fix(release-drafter): fix release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,19 +32,26 @@ template: |
 autolabeler:
   # Tag any PR with "!" in the subject as major update. In other words, breaking change
   - label: "kind/breaking-change"
-    title: "/.*!:.*/"
+    title:
+      - "/.*!:.*/"
   - label: "area/dependencies"
-    title: "chore(deps)"
+    title:
+      - "chore(deps)"
   - label: "area/dependencies"
-    title: "fix(deps)"
+    title:
+      - "fix(deps)"
   - label: "area/dependencies"
-    title: "build(deps)"
+    title:
+      - "build(deps)"
   - label: "kind/feature"
-    title: "feat"
+    title:
+      - "feat"
   - label: "kind/bug"
-    title: "fix"
+    title:
+      - "fix"
   - label: "kind/chore"
-    title: "chore"
+    title:
+      - "chore"
 
 version-resolver:
   major:

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -1,0 +1,16 @@
+name: Autolabeler
+
+on:
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  update_release_draft:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -6,10 +6,6 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read
@@ -19,16 +15,10 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: release-drafter/release-drafter@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Release drafter has a dedicated github action to run the auto labeler. This commit creates a new CI workflow to run it as well as fix the configuration file following the new syntax.

