### PR TITLE
fix(ci): bump provenance version to v1

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -65,7 +65,7 @@ jobs:
           set -e
           DIGEST=$(crane manifest ghcr.io/${{ github.repository_owner }}/sbomscanner/${{ inputs.component }}@${{ env.ATTESTATION_MANIFEST_DIGEST }} |
                       jq -r '.layers[]
-                        | select(.annotations["in-toto.io/predicate-type"] == "https://slsa.dev/provenance/v0.2")
+                        | select(.annotations["in-toto.io/predicate-type"] == "https://slsa.dev/provenance/v1")
                         | .digest')
           echo "PROVENANCE_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
       - name: Find SBOM manifest layer digest


### PR DESCRIPTION
## Description
Update SLSA provenance predicate type from v0.2 to v1

BuildKit's default provenance version changed from v0.2 to v1, causing the attestation workflow to fail with an empty digest when querying for provenance layers.