### PR TITLE
ci(govulncheck): upload results as SARIF to the security tab rather than failing

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -4,6 +4,10 @@ on:
     paths:
       - go.sum
       - go.mod
+  pull_request:
+    paths:
+      - go.sum
+      - go.mod
   schedule:
     - cron: "0 0 * * *"
 
@@ -14,19 +18,43 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    env:
+      GOEXPERIMENT: jsonv2
     steps:
-      # checkout the source, required to have `go.mod`
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
-      - name: govulncheck
+      - name: Run govulncheck
+        # With `output-format: sarif` the action exits 0 even when
+        # vulnerabilities are found; findings are surfaced via the SARIF
+        # upload below. See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
-        env:
-          GOEXPERIMENT: jsonv2
         with:
-          # required to override the default value that is 'stable'
-          # in this way `go-version-file` is going to be taken into account
+          # Override the default 'stable' so go-version-file is actually used
+          # (setup-go gives precedence to go-version over go-version-file).
           go-version-input: ""
-          go-version-file: "go.mod"
+          go-version-file: go.mod
           go-package: ./...
+          output-format: sarif
+          output-file: govulncheck.sarif
+          repo-checkout: false
+      - name: Upload SARIF to GitHub Security tab
+        # Skip for PRs from forks: GitHub strips `security-events: write` from
+        # the token in that case, so the upload would fail. The SARIF is still
+        # available as a workflow artifact (uploaded below) for reviewers.
+        if: github.event.pull_request.head.repo.fork != true
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck
+      - name: Upload SARIF as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: govulncheck-sarif
+          path: govulncheck.sarif
+          if-no-files-found: warn


### PR DESCRIPTION
## Description

This PR reworks the `govulncheck` workflow so vulnerability findings show up in the **Security** tab instead of breaking CI. The job runs `govulncheck` with SARIF output and uploads it via `codeql-action/upload-sarif`.

With `output-format: sarif` the action exits 0 even when vulnerabilities are found, so only real errors fail the job. The workflow also triggers on `pull_request` (in addition to `push` and the daily schedule) so PRs are scanned, and the SARIF is uploaded to the Security tab on every trigger — including the scheduled run — so newly disclosed vulnerabilities show up even when neither `go.mod` nor `go.sum` has changed.

For PRs from forks the Security tab upload is skipped because `security-events: write` is not granted, but the SARIF is still attached as a workflow artifact.

Code scanning alerts in the Security tab are tied to the default branch, so findings become visible and persist once the workflow runs on the merge commit to `main`.