### PR TITLE
fix(storage): wait for NATS subscription before publishing in watcher

### DIFF
--- a/internal/apiserver/storage.go
+++ b/internal/apiserver/storage.go
@@ -21,7 +21,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	basecompatibility "k8s.io/component-base/compatibility"
 	baseversion "k8s.io/component-base/version"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/kubewarden/sbomscanner/api/storage/install"
 	"github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
@@ -67,7 +66,7 @@ type StorageAPIServerConfig struct {
 
 type StorageAPIServer struct {
 	db                        *pgxpool.Pool
-	watchers                  []manager.Runnable
+	watchers                  []storage.Watcher
 	logger                    *slog.Logger
 	server                    *genericapiserver.GenericAPIServer
 	dynamicCertKeyPairContent *dynamiccertificates.DynamicCertKeyPairContent
@@ -206,6 +205,12 @@ func (s *StorageAPIServer) Start(ctx context.Context) error {
 
 	s.logger.DebugContext(ctx, "Starting dynamic certificate controller")
 	go s.dynamicCertKeyPairContent.Run(ctx, 1)
+
+	for _, watcher := range s.watchers {
+		if err := watcher.Setup(ctx); err != nil {
+			return fmt.Errorf("error setting up watcher: %w", err)
+		}
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	for _, watcher := range s.watchers {

--- a/internal/storage/image_registry_store.go
+++ b/internal/storage/image_registry_store.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/storage/repository"
@@ -45,7 +44,7 @@ func NewImageStore(
 	db *pgxpool.Pool,
 	nc *nats.Conn,
 	logger *slog.Logger,
-) (*registry.Store, []manager.Runnable, error) {
+) (*registry.Store, []Watcher, error) {
 	strategy := newImageStrategy(scheme)
 	newFunc := func() runtime.Object { return &storagev1alpha1.Image{} }
 	newListFunc := func() runtime.Object { return &storagev1alpha1.ImageList{} }
@@ -86,7 +85,7 @@ func NewImageStore(
 		return nil, nil, fmt.Errorf("unable to complete store with options: %w", err)
 	}
 
-	return registryStore, []manager.Runnable{natsWatcher}, nil
+	return registryStore, []Watcher{natsWatcher}, nil
 }
 
 type imageTableConvertor struct{}

--- a/internal/storage/sbom_registry_store.go
+++ b/internal/storage/sbom_registry_store.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/storage/repository"
@@ -45,7 +44,7 @@ func NewSBOMStore(
 	db *pgxpool.Pool,
 	nc *nats.Conn,
 	logger *slog.Logger,
-) (*registry.Store, []manager.Runnable, error) {
+) (*registry.Store, []Watcher, error) {
 	strategy := newSBOMStrategy(scheme)
 	newFunc := func() runtime.Object { return &storagev1alpha1.SBOM{} }
 	newListFunc := func() runtime.Object { return &storagev1alpha1.SBOMList{} }
@@ -86,7 +85,7 @@ func NewSBOMStore(
 		return nil, nil, fmt.Errorf("unable to complete store with options: %w", err)
 	}
 
-	return registryStore, []manager.Runnable{natsWatcher}, nil
+	return registryStore, []Watcher{natsWatcher}, nil
 }
 
 type sbomTableConvertor struct{}

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -299,6 +299,7 @@ func (suite *storeTestSuite) TestWatchResourceVersionZero() {
 	w, err := suite.store.Watch(suite.T().Context(), key, opts)
 	suite.Require().NoError(err)
 
+	suite.Require().NoError(suite.watcher.Setup(suite.T().Context()))
 	go suite.watcher.Start(suite.T().Context())
 
 	validateDeletion := func(_ context.Context, _ runtime.Object) error {
@@ -340,6 +341,7 @@ func (suite *storeTestSuite) TestWatchSpecificResourceVersion() {
 	w, err := suite.store.Watch(suite.T().Context(), key, opts)
 	suite.Require().NoError(err)
 
+	suite.Require().NoError(suite.watcher.Setup(suite.T().Context()))
 	go suite.watcher.Start(suite.T().Context())
 
 	tryUpdate := func(input runtime.Object, _ k8sstorage.ResponseMeta) (runtime.Object, *uint64, error) {
@@ -398,6 +400,7 @@ func (suite *storeTestSuite) TestWatchWithLabelSelector() {
 	w, err := suite.store.Watch(suite.T().Context(), key, opts)
 	suite.Require().NoError(err)
 
+	suite.Require().NoError(suite.watcher.Setup(suite.T().Context()))
 	go suite.watcher.Start(suite.T().Context())
 
 	events := mustReadEvents(suite.T(), w, 1)
@@ -476,8 +479,8 @@ func (suite *storeTestSuite) TestHandleMessageNotFoundStillBroadcasts() {
 	suite.Require().NoError(err)
 	defer w.Stop()
 
+	suite.Require().NoError(suite.watcher.Setup(ctx))
 	go suite.watcher.Start(ctx)
-	suite.Require().NoError(suite.nc.Flush())
 
 	sbom := &storagev1alpha1.SBOM{
 		ObjectMeta: metav1.ObjectMeta{
@@ -515,8 +518,8 @@ func (suite *storeTestSuite) TestHandleMessageUIDMismatchBroadcastsPayload() {
 	suite.Require().NoError(err)
 	defer w.Stop()
 
+	suite.Require().NoError(suite.watcher.Setup(ctx))
 	go suite.watcher.Start(ctx)
-	suite.Require().NoError(suite.nc.Flush())
 
 	// Populate the store at default/collide. The stale event published next will carry a different UID for the same namespace/name.
 	storedUID := types.UID("stored-uid")

--- a/internal/storage/vulnerabilityreport_registry_store.go
+++ b/internal/storage/vulnerabilityreport_registry_store.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/storage/repository"
@@ -45,7 +44,7 @@ func NewVulnerabilityReportStore(
 	db *pgxpool.Pool,
 	nc *nats.Conn,
 	logger *slog.Logger,
-) (*registry.Store, []manager.Runnable, error) {
+) (*registry.Store, []Watcher, error) {
 	strategy := newVulnerabilityReportStrategy(scheme)
 
 	newFunc := func() runtime.Object { return &storagev1alpha1.VulnerabilityReport{} }
@@ -86,7 +85,7 @@ func NewVulnerabilityReportStore(
 		return nil, nil, fmt.Errorf("unable to complete store with options: %w", err)
 	}
 
-	return registryStore, []manager.Runnable{natsWatcher}, nil
+	return registryStore, []Watcher{natsWatcher}, nil
 }
 
 type vulnerabilityReportTableConvertor struct{}

--- a/internal/storage/watcher.go
+++ b/internal/storage/watcher.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 )
@@ -23,6 +24,13 @@ type event struct {
 	Object    runtime.RawExtension `json:"object"`
 }
 
+// Watcher is a manager.Runnable that requires a synchronous Setup phase before Start.
+// Setup must return nil before Start is invoked; Start then blocks until the context is cancelled.
+type Watcher interface {
+	manager.Runnable
+	Setup(ctx context.Context) error
+}
+
 // natsWatcher subscribes to NATS watch events and broadcasts them locally.
 type natsWatcher struct {
 	nc               *nats.Conn
@@ -31,6 +39,7 @@ type natsWatcher struct {
 	watchBroadcaster *watch.Broadcaster
 	logger           *slog.Logger
 	store            *store
+	sub              *nats.Subscription
 }
 
 func newNatsWatcher(nc *nats.Conn,
@@ -51,8 +60,10 @@ func newNatsWatcher(nc *nats.Conn,
 	}
 }
 
-// Start begins subscribing to NATS messages on the given subject.
-func (w *natsWatcher) Start(ctx context.Context) error {
+// Setup subscribes to the NATS subject and flushes so the server has acknowledged the subscription before returning.
+// Callers can rely on the watcher being ready to receive events once Setup returns nil.
+// Start must be called afterwards to drive the shutdown lifecycle.
+func (w *natsWatcher) Setup(ctx context.Context) error {
 	sub, err := w.nc.Subscribe(w.subject, func(msg *nats.Msg) {
 		if err := w.handleMessage(ctx, msg); err != nil {
 			w.logger.ErrorContext(ctx, "Failed to handle NATS message",
@@ -65,13 +76,30 @@ func (w *natsWatcher) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to subscribe to NATS subject %s: %w", w.subject, err)
 	}
 
+	// Flush to ensure the server has processed the SUB before we signal readiness.
+	// Without this, messages published immediately after Setup returns could be
+	// routed before the subscription is active on the server side.
+	if err := w.nc.Flush(); err != nil {
+		if err := sub.Unsubscribe(); err != nil {
+			w.logger.ErrorContext(ctx, "Failed to unsubscribe after flush error", "error", err)
+		}
+		return fmt.Errorf("failed to flush NATS subscription for %s: %w", w.subject, err)
+	}
+
+	w.sub = sub
+	return nil
+}
+
+// Start blocks until ctx is cancelled, then unsubscribes from NATS and shuts down the broadcaster.
+// Setup must be called and have returned nil before Start.
+func (w *natsWatcher) Start(ctx context.Context) error {
 	w.logger.InfoContext(ctx, "Watch broadcaster started", "subject", w.subject)
 
 	<-ctx.Done()
 
 	w.logger.InfoContext(ctx, "Shutting down watcher", "subject", w.subject)
 	w.watchBroadcaster.Shutdown()
-	if err := sub.Unsubscribe(); err != nil {
+	if err := w.sub.Unsubscribe(); err != nil {
 		w.logger.ErrorContext(ctx, "Failed to unsubscribe from NATS", "error", err)
 	}
 

--- a/internal/storage/workloadscanreport_registry_store.go
+++ b/internal/storage/workloadscanreport_registry_store.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/storage/repository"
@@ -41,7 +40,7 @@ func NewWorkloadScanReportStore(
 	db *pgxpool.Pool,
 	nc *nats.Conn,
 	logger *slog.Logger,
-) (*registry.Store, []manager.Runnable, error) {
+) (*registry.Store, []Watcher, error) {
 	strategy := newWorkloadScanReportStrategy(scheme)
 
 	newFunc := func() runtime.Object { return &storagev1alpha1.WorkloadScanReport{} }
@@ -92,7 +91,7 @@ func NewWorkloadScanReportStore(
 		return nil, nil, fmt.Errorf("unable to complete store with options: %w", err)
 	}
 
-	return registryStore, []manager.Runnable{natsWatcher, workloadScanReportWatcher}, nil
+	return registryStore, []Watcher{natsWatcher, workloadScanReportWatcher}, nil
 }
 
 type workloadScanReportTableConvertor struct{}

--- a/internal/storage/workloadscanreport_watcher.go
+++ b/internal/storage/workloadscanreport_watcher.go
@@ -26,6 +26,7 @@ type WorkloadScanReportWatcher struct {
 	workloadBroadcaster     *natsBroadcaster
 	workloadScanReportStore *store
 	logger                  *slog.Logger
+	sub                     *nats.Subscription
 }
 
 func newWorkloadScanReportWatcher(
@@ -46,8 +47,10 @@ func newWorkloadScanReportWatcher(
 	}
 }
 
-// Start subscribes to VulnerabilityReport events and generates WorkloadScanReport events.
-func (w *WorkloadScanReportWatcher) Start(ctx context.Context) error {
+// Setup subscribes to VulnerabilityReport events and flushes so the server has acknowledged the subscription before returning.
+// Callers can rely on the watcher being ready to receive events once Setup returns nil.
+// Start must be called afterwards to drive the shutdown lifecycle.
+func (w *WorkloadScanReportWatcher) Setup(ctx context.Context) error {
 	subject := "watch." + vulnerabilityReportResourcePluralName
 
 	sub, err := w.nc.Subscribe(subject, func(msg *nats.Msg) {
@@ -62,12 +65,31 @@ func (w *WorkloadScanReportWatcher) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to subscribe to NATS subject %s: %w", subject, err)
 	}
 
+	// Flush to ensure the server has processed the SUB before we signal readiness.
+	// Without this, messages published immediately after Setup returns could be
+	// routed before the subscription is active on the server side.
+	if err := w.nc.Flush(); err != nil {
+		if err := sub.Unsubscribe(); err != nil {
+			w.logger.ErrorContext(ctx, "Failed to unsubscribe after flush error", "error", err)
+		}
+		return fmt.Errorf("failed to flush NATS subscription for %s: %w", subject, err)
+	}
+
+	w.sub = sub
+	return nil
+}
+
+// Start blocks until ctx is cancelled, then unsubscribes from NATS.
+// Setup must be called and have returned nil before Start.
+func (w *WorkloadScanReportWatcher) Start(ctx context.Context) error {
+	subject := "watch." + vulnerabilityReportResourcePluralName
+
 	w.logger.InfoContext(ctx, "Watcher started", "subject", subject)
 
 	<-ctx.Done()
 
 	w.logger.InfoContext(ctx, "Shutting down watcher", "subject", subject)
-	if err := sub.Unsubscribe(); err != nil {
+	if err := w.sub.Unsubscribe(); err != nil {
 		w.logger.ErrorContext(ctx, "Failed to unsubscribe from NATS", "error", err)
 	}
 

--- a/internal/storage/workloadscanreport_watcher_test.go
+++ b/internal/storage/workloadscanreport_watcher_test.go
@@ -146,6 +146,7 @@ func (suite *workloadScanReportWatcherTestSuite) TestNoMatchingWorkloadScanRepor
 	suite.Require().NoError(err)
 	defer w.Stop()
 
+	suite.Require().NoError(suite.natsWatcher.Setup(ctx))
 	go suite.natsWatcher.Start(ctx)
 
 	watcher := newWorkloadScanReportWatcher(
@@ -156,10 +157,8 @@ func (suite *workloadScanReportWatcherTestSuite) TestNoMatchingWorkloadScanRepor
 		suite.workloadStore,
 		slog.Default(),
 	)
+	suite.Require().NoError(watcher.Setup(ctx))
 	go watcher.Start(ctx)
-
-	// Flush NATS connection to ensure watcher is subscribed before publishing events
-	suite.Require().NoError(suite.nc.Flush())
 
 	vulnReport := storagev1alpha1.VulnerabilityReport{
 		ObjectMeta: metav1.ObjectMeta{
@@ -218,6 +217,7 @@ func (suite *workloadScanReportWatcherTestSuite) TestMultipleWorkloadScanReports
 	suite.Require().NoError(err)
 	defer w.Stop()
 
+	suite.Require().NoError(suite.natsWatcher.Setup(ctx))
 	go suite.natsWatcher.Start(ctx)
 
 	watcher := newWorkloadScanReportWatcher(
@@ -228,10 +228,8 @@ func (suite *workloadScanReportWatcherTestSuite) TestMultipleWorkloadScanReports
 		suite.workloadStore,
 		slog.Default(),
 	)
+	suite.Require().NoError(watcher.Setup(ctx))
 	go watcher.Start(ctx)
-
-	// Flush NATS connection to ensure watcher is subscribed before publishing events
-	suite.Require().NoError(suite.nc.Flush())
 
 	vulnReport := storagev1alpha1.VulnerabilityReport{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION

## Description

`natsWatcher` and `WorkloadScanReportWatcher` expose a `Setup(ctx)` method that runs `nc.Subscribe` followed by `nc.Flush()` synchronously, so the NATS server has acknowledged the `SUB` before `Setup` returns. `Start(ctx)` is a blocking run loop that waits on `ctx.Done()` and unsubscribes on shutdown.

Callers can rely on subscription readiness once `Setup` returns nil, and any subscription error is surfaced immediately instead of being silently dropped.
- Introduce a `Watcher` interface (`manager.Runnable` + `Setup`) and switch the storage registry stores and `StorageAPIServer` to it; `Setup` is invoked before `Start` in the existing errgroup.
- Update store and workloadscanreport watcher tests to call `Setup(ctx)` before `go Start(ctx)` instead of relying on goroutine scheduling + publisher-side `nc.Flush()`.
- Fixes flaky `TestStoreTestSuite/TestHandleMessageNotFoundStillBroadcasts`, `TestWatchResourceVersionZero`, and `TestWatchSpecificResourceVersion`.
