### PR TITLE
fix(ci): sbom digest parsing

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -75,7 +75,9 @@ jobs:
         run: |
           set -e
           DIGEST=$(crane manifest "ghcr.io/${{github.repository_owner}}/sbomscanner/${COMPONENT}@${ATTESTATION_MANIFEST_DIGEST}" |  \
-            jq '.layers | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")) | map(.digest) | join(" ")')
+                      jq -r 'first(.layers[]
+                        | select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")
+                        | .digest)')
           echo "SBOM_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
 
       # We need to upload provenance and SBOM files, plus their signatures under the GitHub Release page.


### PR DESCRIPTION
This pull request makes a small but important improvement to the way the SBOM digest is extracted in the `attestation.yml` GitHub Actions workflow. The change ensures that the digests are output as a newline-delimited list of raw values, rather than as a single space-separated string, which improves compatibility with downstream steps.

- Workflow improvement:
  * Updated the `jq` command in `.github/workflows/attestation.yml` to output each SBOM digest as a raw, newline-delimited value, instead of a single space-separated string. This change uses `jq -r` and iterates over each layer, ensuring more reliable extraction of SBOM digests.## Description
