### PR TITLE
ci: add trivy scan

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -70,17 +70,29 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install Trivy
         env:
           # renovate: datasource=github-releases depName=aquasecurity/trivy
           TRIVY_VERSION: "0.70.0"
         run: |
           set -euo pipefail
-          curl -fsSL -o trivy.tar.gz \
-            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          tar -xzf trivy.tar.gz trivy
+          tarball="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          base="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}"
+          curl -fsSL -o "${tarball}"               "${base}/${tarball}"
+          curl -fsSL -o "${tarball}.sigstore.json" "${base}/${tarball}.sigstore.json"
+          # Verify the tarball was signed by Trivy's release workflow on GitHub
+          # via Sigstore keyless signing. This binds the artifact to the
+          # specific upstream tag's release workflow identity.
+          cosign verify-blob \
+            --bundle "${tarball}.sigstore.json" \
+            --certificate-identity-regexp "^https://github\.com/aquasecurity/trivy/\.github/workflows/.+@refs/tags/v${TRIVY_VERSION}\$" \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            "${tarball}"
+          tar -xzf "${tarball}" trivy
           sudo install -m 0755 trivy /usr/local/bin/trivy
-          rm -f trivy trivy.tar.gz
+          rm -f trivy "${tarball}" "${tarball}.sigstore.json"
           trivy --version
       - name: Run Trivy filesystem scan
         # Exit 0 so findings are surfaced via the SARIF upload below rather

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,4 @@
-name: govulncheck
+name: scan
 on:
   push:
     paths:
@@ -57,4 +57,54 @@ jobs:
         with:
           name: govulncheck-sarif
           path: govulncheck.sarif
+          if-no-files-found: warn
+
+  trivy:
+    name: trivy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install Trivy
+        env:
+          # renovate: datasource=github-releases depName=aquasecurity/trivy
+          TRIVY_VERSION: "0.70.0"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o trivy.tar.gz \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          tar -xzf trivy.tar.gz trivy
+          sudo install -m 0755 trivy /usr/local/bin/trivy
+          rm -f trivy trivy.tar.gz
+          trivy --version
+      - name: Run Trivy filesystem scan
+        # Exit 0 so findings are surfaced via the SARIF upload below rather
+        # than failing the job.
+        run: |
+          trivy fs \
+            --scanners vuln \
+            --format sarif \
+            --output trivy.sarif \
+            --exit-code 0 \
+            go.mod
+      - name: Upload SARIF to GitHub Security tab
+        # Skip for PRs from forks: GitHub strips `security-events: write` from
+        # the token in that case, so the upload would fail. The SARIF is still
+        # available as a workflow artifact (uploaded below) for reviewers.
+        if: github.event.pull_request.head.repo.fork != true
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          sarif_file: trivy.sarif
+          category: trivy
+      - name: Upload SARIF as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-sarif
+          path: trivy.sarif
           if-no-files-found: warn

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,17 @@
   "extends": [
     "github>kubewarden/github-actions//renovate-config/default"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update version variables in GitHub Actions workflows annotated with `# renovate: datasource=... depName=...`",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*[A-Za-z0-9_]+:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ],
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    }
+  ],
   "packageRules": [
     {
       "groupName": "kubernetes",


### PR DESCRIPTION
## Description

Renames the govulncheck workflow to scan and adds a Trivy go.mod filesystem scan as a second job, uploading SARIF to the Security tab so findings show up alongside govulncheck. 

The Trivy version is pinned via a Renovate customManager so bumps land as PRs automatically.
