### PR TITLE
feat: add SeveritySource to VulnerabilityReport

### DIFF
--- a/api/storage/v1alpha1/vulnerabilityreport_types.go
+++ b/api/storage/v1alpha1/vulnerabilityreport_types.go
@@ -130,6 +130,12 @@ type Vulnerability struct {
 	// Severity rating (e.g., "HIGH", "MEDIUM")
 	Severity string `json:"severity" protobuf:"bytes,10,req,name=severity"`
 
+	// SeveritySource identifies the vendor that produced the Severity
+	// (e.g. "nvd", "ghsa", "redhat", "alpine").
+	// Consumers can use this key to look up the matching entry in the CVSS map to display alongside Severity.
+	// May be empty when the source vendor is not known.
+	SeveritySource string `json:"severitySource,omitempty" protobuf:"bytes,16,opt,name=severitySource"`
+
 	// References contains URLs for more information
 	References []string `json:"references,omitempty" protobuf:"bytes,11,rep,name=references"`
 

--- a/docs/crds/CRD-docs-for-docs-repo.adoc
+++ b/docs/crds/CRD-docs-for-docs-repo.adoc
@@ -970,6 +970,10 @@ so we have to restore it. + |  |
 | *`diffID`* __string__ | DiffID of the image layer where the vulnerability was introduced + |  | 
 | *`description`* __string__ | Description of the vulnerability + |  | 
 | *`severity`* __string__ | Severity rating (e.g., "HIGH", "MEDIUM") + |  | 
+| *`severitySource`* __string__ | SeveritySource identifies the vendor that produced the Severity +
+(e.g. "nvd", "ghsa", "redhat", "alpine"). +
+Consumers can use this key to look up the matching entry in the CVSS map to display alongside Severity. +
+May be empty when the source vendor is not known. + |  | 
 | *`references`* __string array__ | References contains URLs for more information + |  | 
 | *`cvss`* __object (keys:string, values:xref:{anchor_prefix}-github-com-kubewarden-sbomscanner-api-storage-v1alpha1-cvss[$$CVSS$$])__ | CVSS scoring details + |  | 
 | *`cwes`* __string array__ | CWEs with which the CVE is classified + |  | 

--- a/docs/crds/CRD-docs-for-docs-repo.md
+++ b/docs/crds/CRD-docs-for-docs-repo.md
@@ -742,6 +742,7 @@ _Appears in:_
 | `diffID` _string_ | DiffID of the image layer where the vulnerability was introduced |  |  |
 | `description` _string_ | Description of the vulnerability |  |  |
 | `severity` _string_ | Severity rating (e.g., "HIGH", "MEDIUM") |  |  |
+| `severitySource` _string_ | SeveritySource identifies the vendor that produced the Severity<br />(e.g. "nvd", "ghsa", "redhat", "alpine").<br />Consumers can use this key to look up the matching entry in the CVSS map to display alongside Severity.<br />May be empty when the source vendor is not known. |  |  |
 | `references` _string array_ | References contains URLs for more information |  |  |
 | `cvss` _object (keys:string, values:[CVSS](#cvss))_ | CVSS scoring details |  |  |
 | `cwes` _string array_ | CWEs with which the CVE is classified |  |  |

--- a/internal/handlers/trivyreport/trivy.go
+++ b/internal/handlers/trivyreport/trivy.go
@@ -86,6 +86,7 @@ func newVulnerability(trivyVuln trivyTypes.DetectedVulnerability) storagev1alpha
 		DiffID:           trivyVuln.Layer.DiffID,
 		Description:      trivyVuln.Description,
 		Severity:         trivyVuln.Severity,
+		SeveritySource:   string(trivyVuln.SeveritySource),
 		References:       trivyVuln.References,
 		CVSS:             newCVSS(trivyVuln.CVSS),
 		CWEs:             trivyVuln.CweIDs,

--- a/internal/handlers/trivyreport/trivy_test.go
+++ b/internal/handlers/trivyreport/trivy_test.go
@@ -68,9 +68,10 @@ func TestNewResultsFromTrivyReport(t *testing.T) {
 							FixedVersions: []string{
 								"0.36.0",
 							},
-							DiffID:      "sha256:d37a3e42d123ca619ceab4bbe3c1e9a96d0a837e5e0e3052b33dbd0e842c5661",
-							Description: "Lorem ipsum",
-							Severity:    storagev1alpha1.SeverityMedium,
+							DiffID:         "sha256:d37a3e42d123ca619ceab4bbe3c1e9a96d0a837e5e0e3052b33dbd0e842c5661",
+							Description:    "Lorem ipsum",
+							Severity:       storagev1alpha1.SeverityMedium,
+							SeveritySource: "ghsa",
 							References: []string{
 								"http://www.openwall.com/lists/oss-security/2025/03/07/2",
 								"https://access.redhat.com/security/cve/CVE-2025-22870",

--- a/pkg/generated/applyconfiguration/storage/v1alpha1/vulnerability.go
+++ b/pkg/generated/applyconfiguration/storage/v1alpha1/vulnerability.go
@@ -32,6 +32,11 @@ type VulnerabilityApplyConfiguration struct {
 	Description *string `json:"description,omitempty"`
 	// Severity rating (e.g., "HIGH", "MEDIUM")
 	Severity *string `json:"severity,omitempty"`
+	// SeveritySource identifies the vendor that produced the Severity
+	// (e.g. "nvd", "ghsa", "redhat", "alpine").
+	// Consumers can use this key to look up the matching entry in the CVSS map to display alongside Severity.
+	// May be empty when the source vendor is not known.
+	SeveritySource *string `json:"severitySource,omitempty"`
 	// References contains URLs for more information
 	References []string `json:"references,omitempty"`
 	// CVSS scoring details
@@ -130,6 +135,14 @@ func (b *VulnerabilityApplyConfiguration) WithDescription(value string) *Vulnera
 // If called multiple times, the Severity field is set to the value of the last call.
 func (b *VulnerabilityApplyConfiguration) WithSeverity(value string) *VulnerabilityApplyConfiguration {
 	b.Severity = &value
+	return b
+}
+
+// WithSeveritySource sets the SeveritySource field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the SeveritySource field is set to the value of the last call.
+func (b *VulnerabilityApplyConfiguration) WithSeveritySource(value string) *VulnerabilityApplyConfiguration {
+	b.SeveritySource = &value
 	return b
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -931,6 +931,13 @@ func schema_sbomscanner_api_storage_v1alpha1_Vulnerability(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"severitySource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SeveritySource identifies the vendor that produced the Severity (e.g. \"nvd\", \"ghsa\", \"redhat\", \"alpine\"). Consumers can use this key to look up the matching entry in the CVSS map to display alongside Severity. May be empty when the source vendor is not known.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"references": {
 						SchemaProps: spec.SchemaProps{
 							Description: "References contains URLs for more information",

--- a/test/crd/storage.sbomscanner.kubewarden.io_vulnerabilityreports.yaml
+++ b/test/crd/storage.sbomscanner.kubewarden.io_vulnerabilityreports.yaml
@@ -163,6 +163,13 @@ spec:
                           severity:
                             description: Severity rating (e.g., "HIGH", "MEDIUM")
                             type: string
+                          severitySource:
+                            description: |-
+                              SeveritySource identifies the vendor that produced the Severity
+                              (e.g. "nvd", "ghsa", "redhat", "alpine").
+                              Consumers can use this key to look up the matching entry in the CVSS map to display alongside Severity.
+                              May be empty when the source vendor is not known.
+                            type: string
                           suppressed:
                             description: |-
                               Suppressed identify when vulnerability has

--- a/test/crd/storage.sbomscanner.kubewarden.io_workloadscanreports.yaml
+++ b/test/crd/storage.sbomscanner.kubewarden.io_workloadscanreports.yaml
@@ -189,6 +189,13 @@ spec:
                                         description: Severity rating (e.g., "HIGH",
                                           "MEDIUM")
                                         type: string
+                                      severitySource:
+                                        description: |-
+                                          SeveritySource identifies the vendor that produced the Severity
+                                          (e.g. "nvd", "ghsa", "redhat", "alpine").
+                                          Consumers can use this key to look up the matching entry in the CVSS map to display alongside Severity.
+                                          May be empty when the source vendor is not known.
+                                        type: string
                                       suppressed:
                                         description: |-
                                           Suppressed identify when vulnerability has

--- a/test/fixtures/golang-1.12-alpine-386.sbomscanner.json
+++ b/test/fixtures/golang-1.12-alpine-386.sbomscanner.json
@@ -25,6 +25,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-36159",
             "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
@@ -62,6 +63,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
             "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
@@ -89,6 +91,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -131,6 +134,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -169,6 +173,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -207,6 +212,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -245,6 +251,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -283,6 +290,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -321,6 +329,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -358,6 +367,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -396,6 +406,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -434,6 +445,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -472,6 +484,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -510,6 +523,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -571,6 +585,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -649,6 +664,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -721,6 +737,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -792,6 +809,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -864,6 +882,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -930,6 +949,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1001,6 +1021,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1082,6 +1103,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1124,6 +1146,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -1185,6 +1208,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -1263,6 +1287,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -1335,6 +1360,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1406,6 +1432,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -1478,6 +1505,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -1544,6 +1572,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1615,6 +1644,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1696,6 +1726,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1738,6 +1769,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1776,6 +1808,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1814,6 +1847,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -1856,6 +1890,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1894,6 +1929,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1932,6 +1968,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1970,6 +2007,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2008,6 +2046,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2046,6 +2085,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2083,6 +2123,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2121,6 +2162,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2159,6 +2201,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2197,6 +2240,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2235,6 +2279,7 @@
           "diffID": "sha256:3e2cf7600e279e883bd1942c3c40709f3748cb24faab3c61c920e8f6ea6fb59c",
           "description": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2022/Oct/37",
             "http://seclists.org/fulldisclosure/2022/Oct/38",

--- a/test/fixtures/golang-1.12-alpine-amd64.sbomscanner-vex.json
+++ b/test/fixtures/golang-1.12-alpine-amd64.sbomscanner-vex.json
@@ -25,6 +25,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-36159",
             "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
@@ -62,6 +63,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
             "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
@@ -89,6 +91,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -131,6 +134,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -169,6 +173,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -207,6 +212,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -245,6 +251,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -283,6 +290,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -321,6 +329,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -358,6 +367,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -396,6 +406,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -434,6 +445,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -472,6 +484,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -510,6 +523,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -571,6 +585,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -649,6 +664,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -721,6 +737,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -792,6 +809,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -864,6 +882,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -930,6 +949,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1001,6 +1021,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1082,6 +1103,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1124,6 +1146,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -1185,6 +1208,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -1263,6 +1287,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -1335,6 +1360,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1406,6 +1432,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -1478,6 +1505,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -1544,6 +1572,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1615,6 +1644,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1696,6 +1726,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1738,6 +1769,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1776,6 +1808,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1814,6 +1847,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -1856,6 +1890,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1894,6 +1929,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1932,6 +1968,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1970,6 +2007,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2008,6 +2046,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2046,6 +2085,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2083,6 +2123,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2121,6 +2162,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2159,6 +2201,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2197,6 +2240,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2235,6 +2279,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2022/Oct/37",
             "http://seclists.org/fulldisclosure/2022/Oct/38",

--- a/test/fixtures/golang-1.12-alpine-amd64.sbomscanner.json
+++ b/test/fixtures/golang-1.12-alpine-amd64.sbomscanner.json
@@ -25,6 +25,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-36159",
             "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
@@ -62,6 +63,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
             "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
@@ -89,6 +91,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -131,6 +134,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -169,6 +173,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -207,6 +212,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -245,6 +251,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -283,6 +290,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -321,6 +329,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -358,6 +367,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -396,6 +406,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -434,6 +445,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -472,6 +484,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -510,6 +523,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -571,6 +585,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -649,6 +664,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -721,6 +737,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -792,6 +809,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -864,6 +882,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -930,6 +949,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1001,6 +1021,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1082,6 +1103,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1124,6 +1146,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -1185,6 +1208,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -1263,6 +1287,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -1335,6 +1360,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1406,6 +1432,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -1478,6 +1505,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -1544,6 +1572,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1615,6 +1644,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1696,6 +1726,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1738,6 +1769,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1776,6 +1808,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1814,6 +1847,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -1856,6 +1890,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1894,6 +1929,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1932,6 +1968,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1970,6 +2007,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2008,6 +2046,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2046,6 +2085,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2083,6 +2123,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2121,6 +2162,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2159,6 +2201,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2197,6 +2240,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2235,6 +2279,7 @@
           "diffID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
           "description": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2022/Oct/37",
             "http://seclists.org/fulldisclosure/2022/Oct/38",

--- a/test/fixtures/golang-1.12-alpine-arm-v6.sbomscanner.json
+++ b/test/fixtures/golang-1.12-alpine-arm-v6.sbomscanner.json
@@ -25,6 +25,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-36159",
             "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
@@ -62,6 +63,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
             "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
@@ -89,6 +91,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -131,6 +134,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -169,6 +173,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -207,6 +212,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -245,6 +251,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -283,6 +290,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -321,6 +329,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -358,6 +367,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -396,6 +406,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -434,6 +445,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -472,6 +484,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -510,6 +523,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -571,6 +585,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -649,6 +664,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -721,6 +737,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -792,6 +809,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -864,6 +882,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -930,6 +949,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1001,6 +1021,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1082,6 +1103,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1124,6 +1146,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -1185,6 +1208,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -1263,6 +1287,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -1335,6 +1360,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1406,6 +1432,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -1478,6 +1505,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -1544,6 +1572,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1615,6 +1644,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1696,6 +1726,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1738,6 +1769,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1776,6 +1808,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1814,6 +1847,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -1856,6 +1890,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1894,6 +1929,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1932,6 +1968,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1970,6 +2007,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2008,6 +2046,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2046,6 +2085,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2083,6 +2123,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2121,6 +2162,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2159,6 +2201,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2197,6 +2240,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2235,6 +2279,7 @@
           "diffID": "sha256:440a94f4189e93b31d5a40316cbc1e9b41868e9f14ea4ff32066154c8dc90a75",
           "description": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2022/Oct/37",
             "http://seclists.org/fulldisclosure/2022/Oct/38",

--- a/test/fixtures/golang-1.12-alpine-arm-v7.sbomscanner.json
+++ b/test/fixtures/golang-1.12-alpine-arm-v7.sbomscanner.json
@@ -25,6 +25,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-36159",
             "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
@@ -62,6 +63,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
             "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
@@ -89,6 +91,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -131,6 +134,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -169,6 +173,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -207,6 +212,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -245,6 +251,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -283,6 +290,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -321,6 +329,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -358,6 +367,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -396,6 +406,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -434,6 +445,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -472,6 +484,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -510,6 +523,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -571,6 +585,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -649,6 +664,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -721,6 +737,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -792,6 +809,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -864,6 +882,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -930,6 +949,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1001,6 +1021,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1082,6 +1103,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1124,6 +1146,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -1185,6 +1208,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -1263,6 +1287,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -1335,6 +1360,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1406,6 +1432,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -1478,6 +1505,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -1544,6 +1572,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1615,6 +1644,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1696,6 +1726,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1738,6 +1769,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1776,6 +1808,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1814,6 +1847,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -1856,6 +1890,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1894,6 +1929,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1932,6 +1968,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1970,6 +2007,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2008,6 +2046,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2046,6 +2085,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2083,6 +2123,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2121,6 +2162,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2159,6 +2201,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2197,6 +2240,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2235,6 +2279,7 @@
           "diffID": "sha256:2f1fbf8a09329e4903e8c8ea1e429cce666ad39f92e2ed39ca02bf5f7db89026",
           "description": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2022/Oct/37",
             "http://seclists.org/fulldisclosure/2022/Oct/38",

--- a/test/fixtures/golang-1.12-alpine-arm64-v8.sbomscanner.json
+++ b/test/fixtures/golang-1.12-alpine-arm64-v8.sbomscanner.json
@@ -25,6 +25,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-36159",
             "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
@@ -62,6 +63,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
             "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
@@ -89,6 +91,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -131,6 +134,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -169,6 +173,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -207,6 +212,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -245,6 +251,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -283,6 +290,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -321,6 +329,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -358,6 +367,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -396,6 +406,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -434,6 +445,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -472,6 +484,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -510,6 +523,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -571,6 +585,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -649,6 +664,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -721,6 +737,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -792,6 +809,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -864,6 +882,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -930,6 +949,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1001,6 +1021,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1082,6 +1103,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1124,6 +1146,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -1185,6 +1208,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -1263,6 +1287,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -1335,6 +1360,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1406,6 +1432,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -1478,6 +1505,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -1544,6 +1572,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1615,6 +1644,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1696,6 +1726,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1738,6 +1769,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1776,6 +1808,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1814,6 +1847,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -1856,6 +1890,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1894,6 +1929,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1932,6 +1968,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1970,6 +2007,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2008,6 +2046,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2046,6 +2085,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2083,6 +2123,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2121,6 +2162,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2159,6 +2201,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2197,6 +2240,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2235,6 +2279,7 @@
           "diffID": "sha256:53745f29fdbf5642c5275f34b9803e69742e082df0a7bb3316ece48ba45c622f",
           "description": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2022/Oct/37",
             "http://seclists.org/fulldisclosure/2022/Oct/38",

--- a/test/fixtures/golang-1.12-alpine-ppc64le.sbomscanner.json
+++ b/test/fixtures/golang-1.12-alpine-ppc64le.sbomscanner.json
@@ -25,6 +25,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-36159",
             "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
@@ -62,6 +63,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
             "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
@@ -89,6 +91,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -131,6 +134,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -169,6 +173,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -207,6 +212,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -245,6 +251,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -283,6 +290,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -321,6 +329,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -358,6 +367,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -396,6 +406,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -434,6 +445,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -472,6 +484,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -510,6 +523,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -571,6 +585,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -649,6 +664,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -721,6 +737,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -792,6 +809,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -864,6 +882,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -930,6 +949,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1001,6 +1021,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1082,6 +1103,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1124,6 +1146,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -1185,6 +1208,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -1263,6 +1287,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -1335,6 +1360,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1406,6 +1432,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -1478,6 +1505,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -1544,6 +1572,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1615,6 +1644,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1696,6 +1726,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1738,6 +1769,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1776,6 +1808,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1814,6 +1847,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -1856,6 +1890,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1894,6 +1929,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1932,6 +1968,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1970,6 +2007,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2008,6 +2046,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2046,6 +2085,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2083,6 +2123,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2121,6 +2162,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2159,6 +2201,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2197,6 +2240,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2235,6 +2279,7 @@
           "diffID": "sha256:3bec41b25b6e0036c44a9be70527a8e9b84e671deb2a43dd88f147f6c7ea0e2d",
           "description": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2022/Oct/37",
             "http://seclists.org/fulldisclosure/2022/Oct/38",

--- a/test/fixtures/golang-1.12-alpine-s390x.sbomscanner.json
+++ b/test/fixtures/golang-1.12-alpine-s390x.sbomscanner.json
@@ -25,6 +25,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-36159",
             "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
@@ -62,6 +63,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
             "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
@@ -89,6 +91,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -131,6 +134,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -169,6 +173,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -207,6 +212,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -245,6 +251,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -283,6 +290,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -321,6 +329,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -358,6 +367,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -396,6 +406,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -434,6 +445,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -472,6 +484,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -510,6 +523,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -571,6 +585,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -649,6 +664,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -721,6 +737,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -792,6 +809,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -864,6 +882,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -930,6 +949,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1001,6 +1021,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1082,6 +1103,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1124,6 +1146,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the \"out\" parameter can be NULL and, on exit, the \"outlen\" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the \"out\" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/security/cve/CVE-2021-3711",
@@ -1185,6 +1208,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
             "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
@@ -1263,6 +1287,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23840",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
@@ -1335,6 +1360,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a \"purpose\" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named \"purpose\" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1406,6 +1432,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/08/26/2",
             "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-3712.json",
@@ -1478,6 +1505,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "The X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL's s_server, s_client and verify tools have support for the \"-crl_download\" option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL's parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/09/14/2",
             "https://access.redhat.com/security/cve/CVE-2020-1971",
@@ -1544,6 +1572,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2021/May/67",
             "http://seclists.org/fulldisclosure/2021/May/68",
@@ -1615,6 +1644,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2021/03/27/1",
             "http://www.openwall.com/lists/oss-security/2021/03/27/2",
@@ -1696,6 +1726,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "OpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).",
           "severity": "LOW",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-23839",
             "https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf",
@@ -1738,6 +1769,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1776,6 +1808,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "http://www.openwall.com/lists/oss-security/2020/11/20/4",
             "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1%40%3Cnotifications.apisix.apache.org%3E",
@@ -1814,6 +1847,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-28831",
             "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
@@ -1856,6 +1890,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_i function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42378",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1894,6 +1929,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the next_input_file function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42379",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1932,6 +1968,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the clrvar function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42380",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -1970,6 +2007,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the hash_init function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42381",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2008,6 +2046,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the getvar_s function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42382",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2046,6 +2085,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42383",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2083,6 +2123,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the handle_special function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42384",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2121,6 +2162,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the evaluate function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42385",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2159,6 +2201,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "A use-after-free in Busybox's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the nvalloc function",
           "severity": "HIGH",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42386",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2197,6 +2240,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "An out-of-bounds heap read in Busybox's unlzma applet leads to information leak and denial of service when crafted LZMA-compressed input is decompressed. This can be triggered by any applet/format that",
           "severity": "MEDIUM",
+          "severitySource": "nvd",
           "references": [
             "https://access.redhat.com/security/cve/CVE-2021-42374",
             "https://claroty.com/team82/research/unboxing-busybox-14-vulnerabilities-uncovered-by-claroty-jfrog",
@@ -2235,6 +2279,7 @@
           "diffID": "sha256:1f106b41b4d67dc533fc0172011dcee125a19ab22080bc960f7b9461a5e33253",
           "description": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
           "severity": "CRITICAL",
+          "severitySource": "nvd",
           "references": [
             "http://seclists.org/fulldisclosure/2022/Oct/37",
             "http://seclists.org/fulldisclosure/2022/Oct/38",


### PR DESCRIPTION
## Description
Adds a new `SeveritySource` field on `Vulnerability` that identifies the vendor that produced the severity (`"nvd"`, `"ghsa"`, `"redhat"`, `"alpine"`, …). 
   
The field is populated directly from the upstream scanner's per-finding source, currently passed through from Trivy.

Consumers should use this key to look up the matching entry in the `cvss` map and display that score alongside `Severity`. This mirrors the lookup pattern Trivy uses in its own SARIF reporter.
If there is no match, the consumer can fallback to default CVSS values, see: 

  https://github.com/aquasecurity/trivy/blob/v0.70.0/pkg/report/sarif.go#L447-L460

  ```go
  func severityToScore(severity string) string {
      switch severity {
      case "CRITICAL":
          return "9.5"
      case "HIGH":
          return "8.0"
      case "MEDIUM":
          return "5.5"
      case "LOW":
          return "2.0"
      default:
          return "0.0"
      }
  }
  ```