### PR TITLE
chore: instruct renovate to not update replace directives in go.mod

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,11 @@
         "/^k8s\\.io/component-base/",
         "/^sigs\\.k8s\\.io/controller-runtime/"
       ]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["replace"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description
Configure Renovate to ignore updates to `replace` directives in `go.mod`. 
