### PR TITLE
feat(telemetry): OTel plumbing

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -15,7 +15,11 @@ COPY api/ api/
 COPY internal/ internal/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=jsonv2 go build -a -o ./controller ./cmd/controller
+ARG VERSION=dev
+
+RUN CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=jsonv2 go build -a \
+    -ldflags "-X github.com/kubewarden/sbomscanner/internal/version.Version=${VERSION}" \
+    -o ./controller ./cmd/controller
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -15,7 +15,11 @@ COPY api/ api/
 COPY internal/ internal/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=jsonv2 go build -a -o ./mcp ./cmd/mcp
+ARG VERSION=dev
+
+RUN CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=jsonv2 go build -a \
+    -ldflags "-X github.com/kubewarden/sbomscanner/internal/version.Version=${VERSION}" \
+    -o ./mcp ./cmd/mcp
 
 # Use distroless as minimal base image to package the mcp binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.storage
+++ b/Dockerfile.storage
@@ -15,7 +15,11 @@ COPY api/ api/
 COPY internal/ internal/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=jsonv2 go build -a -o ./storage ./cmd/storage
+ARG VERSION=dev
+
+RUN CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=jsonv2 go build -a \
+    -ldflags "-X github.com/kubewarden/sbomscanner/internal/version.Version=${VERSION}" \
+    -o ./storage ./cmd/storage
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -15,7 +15,11 @@ COPY api/ api/
 COPY internal/ internal/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=jsonv2 go build -a -o ./worker ./cmd/worker
+ARG VERSION=dev
+
+RUN CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=jsonv2 go build -a \
+    -ldflags "-X github.com/kubewarden/sbomscanner/internal/version.Version=${VERSION}" \
+    -o ./worker ./cmd/worker
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"time"
@@ -94,18 +95,20 @@ func parseFlags() Config {
 }
 
 func main() {
-	var tlsOpts []func(*tls.Config)
 	cfg := parseFlags()
+	if err := run(cfg); err != nil {
+		//nolint:sloglint // No structured logger is available at this scope: run() owns the logger lifecycle.
+		slog.Error("controller exited with error", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(cfg Config) error {
+	var tlsOpts []func(*tls.Config)
 
 	slogLevel, err := cmdutil.ParseLogLevel(cfg.LogLevel)
 	if err != nil {
-		//nolint:sloglint // Use the global logger since the logger is not yet initialized
-		slog.Error(
-			"error parsing log level",
-			"error",
-			err,
-		)
-		os.Exit(1)
+		return fmt.Errorf("parsing log level: %w", err)
 	}
 	opts := slog.HandlerOptions{
 		Level: slogLevel,
@@ -121,8 +124,7 @@ func main() {
 	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
 	shutdownTelemetry, err := telemetry.Setup(signalHandler, "sbomscanner-controller", version.Version)
 	if err != nil {
-		setupLog.Error(err, "failed to initialize telemetry")
-		os.Exit(1)
+		return fmt.Errorf("initializing telemetry: %w", err)
 	}
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -192,29 +194,25 @@ func main() {
 		slogger = slogger.With("task", "init")
 
 		if err := cmdutil.WaitForStorageTypes(signalHandler, ctrl.GetConfigOrDie(), slogger); err != nil {
-			slogger.Error("Storage types are not available.", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("waiting for storage types: %w", err)
 		}
 
 		if err := cmdutil.WaitForJetStream(signalHandler, cfg.NatsURL, natsOpts, slogger); err != nil {
-			slogger.Error("JetStream is not available.", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("waiting for JetStream: %w", err)
 		}
 
 		slogger.Info("Initialization tasks completed successfully.")
-		os.Exit(0)
+		return nil
 	}
 
 	nc, err := nats.Connect(cfg.NatsURL, natsOpts...)
 	if err != nil {
-		setupLog.Error(err, "unable to connect to NATS server", "natsURL", cfg.NatsURL)
-		os.Exit(1)
+		return fmt.Errorf("connecting to NATS server %q: %w", cfg.NatsURL, err)
 	}
 
 	publisher, err := messaging.NewNatsPublisher(signalHandler, nc, slogger)
 	if err != nil {
-		setupLog.Error(err, "unable to create NATS publisher")
-		os.Exit(1)
+		return fmt.Errorf("creating NATS publisher: %w", err)
 	}
 
 	cacheByObject := buildCacheByObject(cfg)
@@ -247,13 +245,11 @@ func main() {
 		},
 	})
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
+		return fmt.Errorf("creating manager: %w", err)
 	}
 
 	if err := controller.SetupIndexer(signalHandler, mgr); err != nil {
-		setupLog.Error(err, "unable to set up indexer")
-		os.Exit(1)
+		return fmt.Errorf("setting up indexer: %w", err)
 	}
 
 	if err := (&controller.ScanJobReconciler{
@@ -261,116 +257,116 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		Publisher: publisher,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ScanJob")
-		os.Exit(1)
+		return fmt.Errorf("creating ScanJob controller: %w", err)
 	}
 
 	if err := (&controller.VulnerabilityReportReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "VulnerabilityReport")
-		os.Exit(1)
+		return fmt.Errorf("creating VulnerabilityReport controller: %w", err)
 	}
 
 	if err := (&controller.RegistryScanRunner{
 		Client: mgr.GetClient(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create runner", "runner", "RegistryScanRunner")
-		os.Exit(1)
+		return fmt.Errorf("creating RegistryScanRunner: %w", err)
 	}
 
 	if cfg.WorkloadScan {
-		if err := (&controller.WorkloadScanReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "WorkloadScan")
-			os.Exit(1)
-		}
-
-		if err := (&controller.ImageWorkloadScanReconciler{
-			Client: mgr.GetClient(),
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "ImageWorkloadScan")
-			os.Exit(1)
+		if err := setupWorkloadScanControllers(mgr); err != nil {
+			return err
 		}
 	}
 
 	if cfg.NodeScan {
-		if err = (&controller.NodeScanRunner{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create runner", "runner", "NodeScanRunner")
-			os.Exit(1)
-		}
-
-		if err = (&controller.NodeScanReconciler{
-			Client: mgr.GetClient(),
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "NodeScan")
-			os.Exit(1)
-		}
-
-		if err = (&controller.NodeScanConfigurationReconciler{
-			Client: mgr.GetClient(),
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "NodeScanConfiguration")
-			os.Exit(1)
-		}
-
-		if err = (&controller.NodeScanJobReconciler{
-			Client:    mgr.GetClient(),
-			Scheme:    mgr.GetScheme(),
-			Publisher: publisher,
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "NodeScanJob")
-			os.Exit(1)
+		if err := setupNodeScanControllers(mgr, publisher); err != nil {
+			return err
 		}
 	}
 
+	// Node scan webhooks are registered even when node scan is disabled, so that
+	// requests to node scan resources are still validated.
 	if err = webhookv1alpha1.SetupNodeScanConfigurationWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "NodeScanConfiguration")
-		os.Exit(1)
+		return fmt.Errorf("creating NodeScanConfiguration webhook: %w", err)
 	}
 
 	if err = webhookv1alpha1.SetupNodeScanJobWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "NodeScanJob")
-		os.Exit(1)
+		return fmt.Errorf("creating NodeScanJob webhook: %w", err)
 	}
 
 	if err = webhookv1alpha1.SetupRegistryWebhookWithManager(mgr, cfg.ServiceAccountNamespace, cfg.ServiceAccountName); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Registry")
-		os.Exit(1)
+		return fmt.Errorf("creating Registry webhook: %w", err)
 	}
 
 	if err = webhookv1alpha1.SetupScanJobWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "ScanJob")
-		os.Exit(1)
+		return fmt.Errorf("creating ScanJob webhook: %w", err)
 	}
 
 	if err = webhookv1alpha1.SetupWorkloadScanConfigurationWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "WorkloadScanConfiguration")
-		os.Exit(1)
+		return fmt.Errorf("creating WorkloadScanConfiguration webhook: %w", err)
 	}
 
 	// +kubebuilder:scaffold:builder
 
 	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
+		return fmt.Errorf("adding healthz check: %w", err)
 	}
 	if err = mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
+		return fmt.Errorf("adding readyz check: %w", err)
 	}
 
 	setupLog.Info("starting manager")
 	if err = mgr.Start(signalHandler); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+		return fmt.Errorf("running manager: %w", err)
 	}
+	return nil
+}
+
+func setupWorkloadScanControllers(mgr ctrl.Manager) error {
+	if err := (&controller.WorkloadScanReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("creating WorkloadScan controller: %w", err)
+	}
+
+	if err := (&controller.ImageWorkloadScanReconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("creating ImageWorkloadScan controller: %w", err)
+	}
+	return nil
+}
+
+func setupNodeScanControllers(mgr ctrl.Manager, publisher *messaging.NatsPublisher) error {
+	if err := (&controller.NodeScanRunner{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("creating NodeScanRunner: %w", err)
+	}
+
+	if err := (&controller.NodeScanReconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("creating NodeScan controller: %w", err)
+	}
+
+	if err := (&controller.NodeScanConfigurationReconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("creating NodeScanConfiguration controller: %w", err)
+	}
+
+	if err := (&controller.NodeScanJobReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Publisher: publisher,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("creating NodeScanJob controller: %w", err)
+	}
+	return nil
 }
 
 func buildCacheByObject(cfg Config) map[client.Object]cache.ByObject {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"log/slog"
@@ -38,6 +39,8 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/controller"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
 	"github.com/kubewarden/sbomscanner/internal/storage"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
+	"github.com/kubewarden/sbomscanner/internal/version"
 	webhookv1alpha1 "github.com/kubewarden/sbomscanner/internal/webhook/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
@@ -107,11 +110,27 @@ func main() {
 	opts := slog.HandlerOptions{
 		Level: slogLevel,
 	}
-	slogHandler := slog.NewJSONHandler(os.Stdout, &opts)
+	slogHandler := telemetry.NewTraceContextHandler(slog.NewJSONHandler(os.Stdout, &opts))
 	slogger := slog.New(slogHandler)
 	logger := logr.FromSlogHandler(slogHandler).WithValues("component", "controller")
 	ctrl.SetLogger(logger)
 	setupLog := logger.WithName("setup")
+
+	signalHandler := ctrl.SetupSignalHandler()
+
+	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+	shutdownTelemetry, err := telemetry.Setup(signalHandler, "sbomscanner-controller", version.Version)
+	if err != nil {
+		setupLog.Error(err, "failed to initialize telemetry")
+		os.Exit(1)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := shutdownTelemetry(shutdownCtx); err != nil {
+			setupLog.Error(err, "telemetry shutdown error")
+		}
+	}()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -162,8 +181,6 @@ func main() {
 	utilruntime.Must(storagev1alpha1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
-
-	signalHandler := ctrl.SetupSignalHandler()
 
 	natsOpts := []nats.Option{
 		nats.RootCAs(cfg.NatsCAFile),

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -22,25 +23,41 @@ import (
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-func main() {
-	var addr string
-	var credentialsDir string
-	var certFile string
-	var keyFile string
-	var readOnly bool
-	var logLevel string
-	var disableTLS bool
+type Config struct {
+	Addr           string
+	CredentialsDir string
+	CertFile       string
+	KeyFile        string
+	ReadOnly       bool
+	LogLevel       string
+	DisableTLS     bool
+}
 
-	flag.StringVar(&addr, "addr", ":8222", "HTTP listen address.")
-	flag.StringVar(&credentialsDir, "credentials-dir", "/etc/mcp/credentials", "Directory containing username and password files.")
-	flag.StringVar(&certFile, "cert-file", "/tls/tls.crt", "Path to TLS certificate file.")
-	flag.StringVar(&keyFile, "key-file", "/tls/tls.key", "Path to TLS private key file.")
-	flag.BoolVar(&readOnly, "read-only", false, "Run in read-only mode (no create/update/delete tools).")
-	flag.StringVar(&logLevel, "log-level", slog.LevelInfo.String(), "Log level.")
-	flag.BoolVar(&disableTLS, "disable-tls", false, "Disable TLS and serve plain HTTP.")
+func parseFlags() Config {
+	var cfg Config
+
+	flag.StringVar(&cfg.Addr, "addr", ":8222", "HTTP listen address.")
+	flag.StringVar(&cfg.CredentialsDir, "credentials-dir", "/etc/mcp/credentials", "Directory containing username and password files.")
+	flag.StringVar(&cfg.CertFile, "cert-file", "/tls/tls.crt", "Path to TLS certificate file.")
+	flag.StringVar(&cfg.KeyFile, "key-file", "/tls/tls.key", "Path to TLS private key file.")
+	flag.BoolVar(&cfg.ReadOnly, "read-only", false, "Run in read-only mode (no create/update/delete tools).")
+	flag.StringVar(&cfg.LogLevel, "log-level", slog.LevelInfo.String(), "Log level.")
+	flag.BoolVar(&cfg.DisableTLS, "disable-tls", false, "Disable TLS and serve plain HTTP.")
 	flag.Parse()
+	return cfg
+}
 
-	slogLevel, err := cmdutil.ParseLogLevel(logLevel)
+func main() {
+	cfg := parseFlags()
+	if err := run(cfg); err != nil {
+		//nolint:sloglint // No structured logger is available at this scope: run() owns the logger lifecycle.
+		slog.Error("mcp exited with error", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(cfg Config) error {
+	slogLevel, err := cmdutil.ParseLogLevel(cfg.LogLevel)
 	if err != nil {
 		//nolint:sloglint // Use the global logger since the logger is not yet initialized
 		slog.Error(
@@ -65,8 +82,7 @@ func main() {
 	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
 	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-mcp", version.Version)
 	if err != nil {
-		logger.Error("Failed to initialize telemetry", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("initializing telemetry: %w", err)
 	}
 	defer func() {
 		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 5*time.Second)
@@ -78,28 +94,24 @@ func main() {
 
 	s := scheme.Scheme
 	if err := v1alpha1.AddToScheme(s); err != nil {
-		logger.Error("Error adding v1alpha1 to scheme", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("adding v1alpha1 to scheme: %w", err)
 	}
 	if err := storagev1alpha1.AddToScheme(s); err != nil {
-		logger.Error("Error adding storagev1alpha1 to scheme", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("adding storagev1alpha1 to scheme: %w", err)
 	}
 	if err := k8sscheme.AddToScheme(s); err != nil {
-		logger.Error("Error adding kubernetes to scheme", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("adding kubernetes to scheme: %w", err)
 	}
 
 	config := ctrl.GetConfigOrDie()
 	k8sClient, err := client.New(config, client.Options{Scheme: s})
 	if err != nil {
-		logger.Error("Error creating k8s client", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("creating k8s client: %w", err)
 	}
 
-	server := mcpserver.NewServer(k8sClient, logger, readOnly)
-	if err := server.Run(ctx, addr, credentialsDir, certFile, keyFile, disableTLS); err != nil {
-		logger.Error("Error running MCP server", "error", err)
-		os.Exit(1)
+	server := mcpserver.NewServer(k8sClient, logger, cfg.ReadOnly)
+	if err := server.Run(ctx, cfg.Addr, cfg.CredentialsDir, cfg.CertFile, cfg.KeyFile, cfg.DisableTLS); err != nil {
+		return fmt.Errorf("running MCP server: %w", err)
 	}
+	return nil
 }

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,6 +16,8 @@ import (
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/cmdutil"
 	mcpserver "github.com/kubewarden/sbomscanner/internal/mcp"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
+	"github.com/kubewarden/sbomscanner/internal/version"
 	"github.com/kubewarden/sbomscanner/pkg/generated/clientset/versioned/scheme"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -46,9 +49,9 @@ func main() {
 		slogLevel = slog.LevelInfo
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	logger := slog.New(telemetry.NewTraceContextHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slogLevel,
-	})).With("component", "mcp")
+	}))).With("component", "mcp")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	signalChan := make(chan os.Signal, 1)
@@ -57,6 +60,20 @@ func main() {
 	go func() {
 		<-signalChan
 		cancel()
+	}()
+
+	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-mcp", version.Version)
+	if err != nil {
+		logger.Error("Failed to initialize telemetry", "error", err)
+		os.Exit(1)
+	}
+	defer func() {
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelShutdown()
+		if err := shutdownTelemetry(shutdownCtx); err != nil {
+			logger.Error("Telemetry shutdown error", "error", err)
+		}
 	}()
 
 	s := scheme.Scheme

--- a/cmd/storage/main.go
+++ b/cmd/storage/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/klog/v2"
@@ -21,6 +22,8 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/apiserver"
 	"github.com/kubewarden/sbomscanner/internal/cmdutil"
 	"github.com/kubewarden/sbomscanner/internal/storage"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
+	"github.com/kubewarden/sbomscanner/internal/version"
 )
 
 func main() {
@@ -72,13 +75,26 @@ func run() error {
 		Level: slogLevel,
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &opts)).With("component", "storage")
+	logger := slog.New(telemetry.NewTraceContextHandler(slog.NewJSONHandler(os.Stdout, &opts))).With("component", "storage")
 	logger.Info("Starting storage")
 
 	// Kubernetes components use klog for logging, so we need to redirect it to our slog logger.
 	klog.SetSlogLogger(logger)
 
 	ctx := genericapiserver.SetupSignalContext()
+
+	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-storage", version.Version)
+	if err != nil {
+		return fmt.Errorf("initializing telemetry: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := shutdownTelemetry(shutdownCtx); err != nil {
+			logger.Error("Telemetry shutdown error", "error", err)
+		}
+	}()
 
 	maxRequestBodyBytes, err := units.FromHumanSize(maxRequestBodySize)
 	if err != nil {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"log/slog"
 	"net/http"
@@ -233,7 +234,7 @@ func runHealthServer(logger *slog.Logger) *http.Server {
 
 	go func() {
 		logger.Info("Starting health check server", "addr", ":8081")
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Error("Health check server error", "error", err)
 		}
 	}()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/handlers"
 	"github.com/kubewarden/sbomscanner/internal/handlers/registry"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
+	"github.com/kubewarden/sbomscanner/internal/version"
 	"github.com/kubewarden/sbomscanner/pkg/generated/clientset/versioned/scheme"
 	"github.com/nats-io/nats.go"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -72,7 +74,7 @@ func main() {
 	opts := slog.HandlerOptions{
 		Level: slogLevel,
 	}
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &opts)).With("component", "worker")
+	logger := slog.New(telemetry.NewTraceContextHandler(slog.NewJSONHandler(os.Stdout, &opts))).With("component", "worker")
 	logger.Info("Starting worker")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -82,6 +84,20 @@ func main() {
 	go func() {
 		<-signalChan
 		cancel()
+	}()
+
+	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-worker", version.Version)
+	if err != nil {
+		logger.Error("Failed to initialize telemetry", "error", err)
+		os.Exit(1)
+	}
+	defer func() {
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelShutdown()
+		if err := shutdownTelemetry(shutdownCtx); err != nil {
+			logger.Error("Telemetry shutdown error", "error", err)
+		}
 	}()
 
 	config := ctrl.GetConfigOrDie()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -34,43 +35,53 @@ const (
 	registryMode = "registry"
 )
 
-func main() {
-	var natsURL string
-	var natsCertFile string
-	var natsKeyFile string
-	var natsCAFile string
-	var runDir string
-	var trivyDBRepository string
-	var trivyJavaDBRepository string
-	var installationNamespace string
-	var init bool
-	var logLevel string
-	var mode string
-	var nodeName string
+type Config struct {
+	NatsURL               string
+	NatsCertFile          string
+	NatsKeyFile           string
+	NatsCAFile            string
+	RunDir                string
+	TrivyDBRepository     string
+	TrivyJavaDBRepository string
+	InstallationNamespace string
+	Init                  bool
+	LogLevel              string
+	Mode                  string
+	NodeName              string
+}
 
-	flag.StringVar(&natsURL, "nats-url", "localhost:4222", "The URL of the NATS server.")
-	flag.StringVar(&natsCertFile, "nats-cert-file", "/nats/tls/tls.crt", "The path to the NATS client certificate.")
-	flag.StringVar(&natsKeyFile, "nats-key-file", "/nats/tls/tls.key", "The path to the NATS client key.")
-	flag.StringVar(&natsCAFile, "nats-ca-file", "/nats/tls/ca.crt", "The path to the NATS CA certificate.")
-	flag.StringVar(&runDir, "run-dir", "/var/run/worker", "Directory to store temporary files.")
-	flag.StringVar(&trivyDBRepository, "trivy-db-repository", "public.ecr.aws/aquasecurity/trivy-db", "OCI repository to retrieve trivy-db.")
-	flag.StringVar(&trivyJavaDBRepository, "trivy-java-db-repository", "public.ecr.aws/aquasecurity/trivy-java-db", "OCI repository to retrieve trivy-java-db.")
-	flag.StringVar(&installationNamespace, "installation-namespace", "sbomscanner", "The namespace where sbomscanner is installed.")
-	flag.BoolVar(&init, "init", false, "Run initialization tasks and exit.")
-	flag.StringVar(&logLevel, "log-level", slog.LevelInfo.String(), "Log level.")
-	flag.StringVar(&mode, "mode", "registry", "Mode of operation ('registry' or 'node').")
-	flag.StringVar(&nodeName, "node-name", "", "The name of the node (required if mode is 'node').")
+func parseFlags() Config {
+	var cfg Config
+
+	flag.StringVar(&cfg.NatsURL, "nats-url", "localhost:4222", "The URL of the NATS server.")
+	flag.StringVar(&cfg.NatsCertFile, "nats-cert-file", "/nats/tls/tls.crt", "The path to the NATS client certificate.")
+	flag.StringVar(&cfg.NatsKeyFile, "nats-key-file", "/nats/tls/tls.key", "The path to the NATS client key.")
+	flag.StringVar(&cfg.NatsCAFile, "nats-ca-file", "/nats/tls/ca.crt", "The path to the NATS CA certificate.")
+	flag.StringVar(&cfg.RunDir, "run-dir", "/var/run/worker", "Directory to store temporary files.")
+	flag.StringVar(&cfg.TrivyDBRepository, "trivy-db-repository", "public.ecr.aws/aquasecurity/trivy-db", "OCI repository to retrieve trivy-db.")
+	flag.StringVar(&cfg.TrivyJavaDBRepository, "trivy-java-db-repository", "public.ecr.aws/aquasecurity/trivy-java-db", "OCI repository to retrieve trivy-java-db.")
+	flag.StringVar(&cfg.InstallationNamespace, "installation-namespace", "sbomscanner", "The namespace where sbomscanner is installed.")
+	flag.BoolVar(&cfg.Init, "init", false, "Run initialization tasks and exit.")
+	flag.StringVar(&cfg.LogLevel, "log-level", slog.LevelInfo.String(), "Log level.")
+	flag.StringVar(&cfg.Mode, "mode", "registry", "Mode of operation ('registry' or 'node').")
+	flag.StringVar(&cfg.NodeName, "node-name", "", "The name of the node (required if mode is 'node').")
 	flag.Parse()
+	return cfg
+}
 
-	slogLevel, err := cmdutil.ParseLogLevel(logLevel)
-	if err != nil {
-		//nolint:sloglint // Use the global logger since the logger is not yet initialized
-		slog.Error(
-			"error initializing the logger",
-			"error",
-			err,
-		)
+func main() {
+	cfg := parseFlags()
+	if err := run(cfg); err != nil {
+		//nolint:sloglint // No structured logger is available at this scope: run() owns the logger lifecycle.
+		slog.Error("worker exited with error", "error", err)
 		os.Exit(1)
+	}
+}
+
+func run(cfg Config) error {
+	slogLevel, err := cmdutil.ParseLogLevel(cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("parsing log level: %w", err)
 	}
 	opts := slog.HandlerOptions{
 		Level: slogLevel,
@@ -90,8 +101,7 @@ func main() {
 	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
 	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-worker", version.Version)
 	if err != nil {
-		logger.Error("Failed to initialize telemetry", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("initializing telemetry: %w", err)
 	}
 	defer func() {
 		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 5*time.Second)
@@ -103,63 +113,54 @@ func main() {
 
 	config := ctrl.GetConfigOrDie()
 	natsOpts := []nats.Option{
-		nats.RootCAs(natsCAFile),
-		nats.ClientCert(natsCertFile, natsKeyFile),
+		nats.RootCAs(cfg.NatsCAFile),
+		nats.ClientCert(cfg.NatsCertFile, cfg.NatsKeyFile),
 	}
 
-	if init {
+	if cfg.Init {
 		logger = logger.With("task", "init")
 
 		if err := cmdutil.WaitForStorageTypes(ctx, config, logger); err != nil {
-			logger.Error("Error waiting for storage types", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("waiting for storage types: %w", err)
 		}
 
-		if err := cmdutil.WaitForJetStream(ctx, natsURL, natsOpts, logger); err != nil {
-			logger.Error("Error waiting for JetStream", "error", err)
-			os.Exit(1)
+		if err := cmdutil.WaitForJetStream(ctx, cfg.NatsURL, natsOpts, logger); err != nil {
+			return fmt.Errorf("waiting for JetStream: %w", err)
 		}
 
 		logger.Info("Initialization tasks completed successfully.")
-		os.Exit(0)
+		return nil
 	}
 
-	if mode == nodeMode && nodeName == "" {
-		logger.Error("Node name must be provided when mode is 'node'")
-		os.Exit(1)
+	if cfg.Mode == nodeMode && cfg.NodeName == "" {
+		return errors.New("node name required in node mode")
 	}
 
-	nc, err := nats.Connect(natsURL,
+	nc, err := nats.Connect(cfg.NatsURL,
 		natsOpts...,
 	)
 	if err != nil {
-		logger.Error("Unable to connect to NATS server", "error", err, "natsURL", natsURL)
-		os.Exit(1)
+		return fmt.Errorf("connecting to NATS server %q: %w", cfg.NatsURL, err)
 	}
 
 	publisher, err := messaging.NewNatsPublisher(ctx, nc, logger)
 	if err != nil {
-		logger.Error("Error creating NATS publisher", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("creating NATS publisher: %w", err)
 	}
 
 	scheme := scheme.Scheme
 	if err = v1alpha1.AddToScheme(scheme); err != nil {
-		logger.Error("Error adding v1alpha1 to scheme", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("adding v1alpha1 to scheme: %w", err)
 	}
 	if err = storagev1alpha1.AddToScheme(scheme); err != nil {
-		logger.Error("Error adding storagev1alpha1 to scheme", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("adding storagev1alpha1 to scheme: %w", err)
 	}
 	if err = k8sscheme.AddToScheme(scheme); err != nil {
-		logger.Error("Error adding kubernetes to scheme", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("adding kubernetes to scheme: %w", err)
 	}
 	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
-		logger.Error("Error creating k8s client", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("creating k8s client: %w", err)
 	}
 	registryClientFactory := func(transport http.RoundTripper) *registry.Client {
 		return registry.NewClient(transport, logger)
@@ -167,26 +168,25 @@ func main() {
 
 	var scanMode messaging.HandlerRegistry
 	durableName := "worker"
-	switch mode {
+	switch cfg.Mode {
 	case registryMode:
 		scanMode = messaging.HandlerRegistry{
-			handlers.CreateCatalogSubject: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, publisher, installationNamespace, logger),
-			handlers.GenerateSBOMSubject:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, runDir, trivyJavaDBRepository, publisher, installationNamespace, logger),
-			handlers.ScanSBOMSubject:      handlers.NewScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, logger),
+			handlers.CreateCatalogSubject: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, publisher, cfg.InstallationNamespace, logger),
+			handlers.GenerateSBOMSubject:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyJavaDBRepository, publisher, cfg.InstallationNamespace, logger),
+			handlers.ScanSBOMSubject:      handlers.NewScanSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyDBRepository, cfg.TrivyJavaDBRepository, logger),
 		}
 	case nodeMode:
 		scanMode = messaging.HandlerRegistry{
-			handlers.GenerateNodeSBOMSubject + "." + nodeName: handlers.NewGenerateNodeSBOMHandler(k8sClient, scheme, runDir, targetDir, trivyJavaDBRepository, publisher, installationNamespace, logger),
-			handlers.ScanNodeSBOMSubject + "." + nodeName:     handlers.NewNodeScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, logger),
+			handlers.GenerateNodeSBOMSubject + "." + cfg.NodeName: handlers.NewGenerateNodeSBOMHandler(k8sClient, scheme, cfg.RunDir, targetDir, cfg.TrivyJavaDBRepository, publisher, cfg.InstallationNamespace, logger),
+			handlers.ScanNodeSBOMSubject + "." + cfg.NodeName:     handlers.NewNodeScanSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyDBRepository, cfg.TrivyJavaDBRepository, logger),
 		}
-		durableName = "worker-node-" + nodeName
+		durableName = "worker-node-" + cfg.NodeName
 	default:
-		logger.Error("Invalid scanning mode", "mode", mode)
-		os.Exit(1)
+		return fmt.Errorf("invalid scanning mode: %s", cfg.Mode)
 	}
 
 	var failureHandler messaging.FailureHandler
-	switch mode {
+	switch cfg.Mode {
 	case nodeMode:
 		failureHandler = handlers.NewNodeScanJobFailureHandler(k8sClient, logger)
 	default:
@@ -200,23 +200,21 @@ func main() {
 
 	subscriber, err := messaging.NewNatsSubscriber(ctx, nc, durableName, scanMode, failureHandler, retryConfig, logger)
 	if err != nil {
-		logger.Error("Error creating NATS subscriber", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("creating NATS subscriber: %w", err)
 	}
 
 	healthServer := runHealthServer(logger)
 
 	err = subscriber.Run(ctx)
 	if err != nil {
-		logger.Error("Error running worker subscriber", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("running worker subscriber: %w", err)
 	}
 
 	logger.Debug("Shutting down health server")
 	if err := healthServer.Close(); err != nil {
-		logger.Error("Error shutting down health check server", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("shutting down health check server: %w", err)
 	}
+	return nil
 }
 
 func runHealthServer(logger *slog.Logger) *http.Server {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,13 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/registry v0.43.0
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.15.0
@@ -430,14 +437,7 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -107,11 +108,11 @@ func (s *Server) Run(ctx context.Context, addr, credentialsDir, certFile, keyFil
 
 	s.logger.InfoContext(ctx, "Listening", "addr", addr, "tls", !disableTLS)
 	if disableTLS {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			return fmt.Errorf("listening on %s: %w", addr, err)
 		}
 	} else {
-		if err := srv.ListenAndServeTLS(certFile, keyFile); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServeTLS(certFile, keyFile); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			return fmt.Errorf("listening on %s: %w", addr, err)
 		}
 	}

--- a/internal/telemetry/doc.go
+++ b/internal/telemetry/doc.go
@@ -1,0 +1,2 @@
+// Package telemetry is the OpenTelemetry plumbing for sbomscanner binaries.
+package telemetry

--- a/internal/telemetry/nats.go
+++ b/internal/telemetry/nats.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import (
+	"context"
+
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// natsHeaderCarrier adapts nats.Header to the TextMapCarrier interface,
+// so the global OTel propagator can inject/extract W3C `traceparent`
+// (and any other configured propagators) directly into JetStream message headers.
+//
+// NATS headers permit repeated keys, but this carrier follows net/http semantics:
+// Set overwrites any existing entry, and Get returns the first value for the key.
+type natsHeaderCarrier nats.Header
+
+var _ propagation.TextMapCarrier = natsHeaderCarrier{}
+
+// Get returns the first value associated with key, or an empty string if absent.
+func (carrier natsHeaderCarrier) Get(key string) string {
+	values := nats.Header(carrier).Values(key)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+// Set stores value under key, overwriting any existing entry.
+func (carrier natsHeaderCarrier) Set(key, value string) {
+	nats.Header(carrier).Set(key, value)
+}
+
+// Keys returns every header key present in the carrier.
+func (carrier natsHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(carrier))
+	for key := range carrier {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// InjectNATS writes the trace context from ctx into msg.Header using the globally configured TextMapPropagator.
+// The header is created if needed.
+// Safe to call when telemetry is disabled, since the no-op propagator simply writes nothing.
+func InjectNATS(ctx context.Context, msg *nats.Msg) {
+	if msg == nil {
+		return
+	}
+	if msg.Header == nil {
+		msg.Header = nats.Header{}
+	}
+	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(msg.Header))
+}
+
+// ExtractNATS returns a context derived from parent that carries the trace context found in hdr.
+// When telemetry is disabled or no propagation headers are present, the parent context is returned unchanged.
+func ExtractNATS(parent context.Context, hdr nats.Header) context.Context {
+	if hdr == nil {
+		return parent
+	}
+	return otel.GetTextMapPropagator().Extract(parent, natsHeaderCarrier(hdr))
+}

--- a/internal/telemetry/nats_test.go
+++ b/internal/telemetry/nats_test.go
@@ -1,0 +1,102 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TestNATSCarrier_RoundTrip injects a context into NATS headers and extracts it back,
+// asserting the same trace context is recovered.
+// This is the exact path used by NatsPublisher / NatsSubscriber in Task 1.
+func TestNATSCarrier_RoundTrip(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	tracerProvider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tracerProvider.Shutdown(context.Background()) })
+
+	producerCtx, span := tracerProvider.Tracer("test").Start(context.Background(), "produce")
+	defer span.End()
+	expectedSpanContext := span.SpanContext()
+
+	msg := &nats.Msg{Subject: "sbomscanner.test"}
+	InjectNATS(producerCtx, msg)
+
+	require.NotEmpty(t, msg.Header.Get("traceparent"),
+		"traceparent header must be set by InjectNATS")
+
+	consumerCtx := ExtractNATS(context.Background(), msg.Header)
+	extractedSpanContext := trace.SpanContextFromContext(consumerCtx)
+
+	assert.Equal(t, expectedSpanContext.TraceID(), extractedSpanContext.TraceID())
+	assert.Equal(t, expectedSpanContext.SpanID(), extractedSpanContext.SpanID())
+}
+
+// TestInjectNATS_NilMsg asserts that InjectNATS is safe to call with a nil message,
+// returning without panicking so publisher call sites don't need a guard.
+func TestInjectNATS_NilMsg(t *testing.T) {
+	assert.NotPanics(t, func() {
+		InjectNATS(context.Background(), nil)
+	})
+}
+
+// TestInjectNATS_CreatesHeader lazily allocates msg.Header when it is nil,
+// instead of panicking on map assignment.
+func TestInjectNATS_CreatesHeader(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	tracerProvider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tracerProvider.Shutdown(context.Background()) })
+	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "op")
+	defer span.End()
+
+	msg := &nats.Msg{Subject: "sbomscanner.test"} // Header is nil
+	InjectNATS(ctx, msg)
+
+	require.NotNil(t, msg.Header)
+	assert.NotEmpty(t, msg.Header.Get("traceparent"))
+}
+
+// TestExtractNATS_NilHeader returns the parent context unchanged,
+// so consumers can call it without pre-checking.
+func TestExtractNATS_NilHeader(t *testing.T) {
+	parentCtx := context.Background()
+	extractedCtx := ExtractNATS(parentCtx, nil)
+	assert.Equal(t, parentCtx, extractedCtx)
+}
+
+// TestExtractNATS_NoTraceparent returns a context with an invalid SpanContext,
+// when the header has no propagation keys.
+func TestExtractNATS_NoTraceparent(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	hdr := nats.Header{}
+	hdr.Set("Nats-Msg-Id", "abc")
+
+	extractedCtx := ExtractNATS(context.Background(), hdr)
+	assert.False(t, trace.SpanContextFromContext(extractedCtx).IsValid())
+}
+
+// TestNATSHeaderCarrier_Keys returns every header key,
+// matching the TextMapCarrier contract.
+func TestNATSHeaderCarrier_Keys(t *testing.T) {
+	hdr := nats.Header{}
+	hdr.Set("traceparent", "00-...")
+	hdr.Set("Nats-Msg-Id", "id")
+
+	keys := natsHeaderCarrier(hdr).Keys()
+	assert.ElementsMatch(t, []string{"traceparent", "Nats-Msg-Id"}, keys)
+}
+
+// TestNATSHeaderCarrier_GetMissing returns an empty string for absent keys,
+// per the TextMapCarrier contract.
+func TestNATSHeaderCarrier_GetMissing(t *testing.T) {
+	assert.Empty(t, natsHeaderCarrier(nats.Header{}).Get("traceparent"))
+}

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -1,0 +1,147 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// ShutdownFunc flushes and stops the providers installed by Setup.
+// It is always safe to call (no-op when telemetry is disabled).
+type ShutdownFunc func(ctx context.Context) error
+
+// otlpEndpointEnv is the environment variable inspected to decide whether telemetry export is enabled.
+// When unset, Setup is a no-op.
+//
+// We deliberately check only the unsigned/general endpoint variable.
+// Users who want to enable only one signal can set both OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_TRACES_SAMPLER=always_off
+// (or the metric equivalent) per the OTel spec.
+const otlpEndpointEnv = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+// Setup installs global Tracer and Meter providers and the W3C TraceContext + Baggage propagators.
+//
+// When OTEL_EXPORTER_OTLP_ENDPOINT is unset, Setup installs the W3C propagators, leaves the global
+// TracerProvider and MeterProvider as their default no-op implementations, and returns a no-op shutdown function.
+// Otherwise it constructs OTLP/gRPC trace and metric exporters
+// (which themselves read OTEL_EXPORTER_OTLP_* environment variables)
+// and wires them through a BatchSpanProcessor and a PeriodicReader.
+//
+// serviceName and serviceVersion populate the standard resource attributes,
+// and are overridable via OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES.
+func Setup(ctx context.Context, serviceName, serviceVersion string) (ShutdownFunc, error) {
+	// Always install W3C propagators so application code can call otel.GetTextMapPropagator() without branching on whether export is enabled.
+	// Propagation through NATS headers (see nats.go) is a pure in-process concern and works even with no-op providers.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	if os.Getenv(otlpEndpointEnv) == "" {
+		// No-op shutdown.
+		// The default global TracerProvider and MeterProvider are already no-op implementations.
+		return func(context.Context) error { return nil }, nil
+	}
+
+	res, err := buildResource(ctx, serviceName, serviceVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building otel resource: %w", err)
+	}
+
+	traceExporter, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating OTLP trace exporter: %w", err)
+	}
+
+	metricExporter, err := otlpmetricgrpc.New(ctx)
+	if err != nil {
+		// Roll back the trace exporter so we don't leak its gRPC connection.
+		// Uses a fresh context so a cancelled caller ctx still lets the exporter flush.
+		// The rollback error (if any) is joined onto the returned error, never dropped.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return nil, errors.Join(
+			fmt.Errorf("creating OTLP metric exporter: %w", err),
+			traceExporter.Shutdown(shutdownCtx),
+		)
+	}
+
+	tracerProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tracerProvider)
+
+	meterProvider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(meterProvider)
+
+	shutdown := func(ctx context.Context) error {
+		// Best-effort: try both, surface both errors.
+		return errors.Join(
+			tracerProvider.Shutdown(ctx),
+			meterProvider.Shutdown(ctx),
+		)
+	}
+
+	return shutdown, nil
+}
+
+// downwardAPIEnv maps the environment variables wired by the Helm Deployments (downward API) to OTel semantic-convention attribute keys.
+// Empty values are skipped so we don't fabricate hollow attributes.
+var downwardAPIEnv = []struct {
+	env string
+	key attribute.Key
+}{
+	{"K8S_POD_NAME", semconv.K8SPodNameKey},
+	{"K8S_POD_NAMESPACE", semconv.K8SNamespaceNameKey},
+	{"K8S_NODE_NAME", semconv.K8SNodeNameKey},
+	{"K8S_POD_UID", semconv.K8SPodUIDKey},
+	{"K8S_CONTAINER_NAME", semconv.K8SContainerNameKey},
+}
+
+// buildResource merges SDK defaults
+// (which already include attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME)
+// with the service name and version supplied by the caller,
+// plus any Kubernetes pod metadata exposed by the chart.
+func buildResource(ctx context.Context, serviceName, serviceVersion string) (*resource.Resource, error) {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(serviceName),
+		semconv.ServiceVersion(serviceVersion),
+	}
+	for _, e := range downwardAPIEnv {
+		if v := os.Getenv(e.env); v != "" {
+			attrs = append(attrs, e.key.String(v))
+		}
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithFromEnv(),
+		resource.WithProcess(),
+		resource.WithHost(),
+		resource.WithTelemetrySDK(),
+		resource.WithAttributes(attrs...),
+	)
+	if err != nil {
+		// resource.New can return a partial resource with a non-fatal error
+		// (e.g. schema URL conflicts when merging).
+		// Surface the resource if we have one and let the SDK use it.
+		if res == nil {
+			return nil, fmt.Errorf("creating otel resource: %w", err)
+		}
+	}
+	return res, nil
+}

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -1,0 +1,30 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+)
+
+// TestSetup_NoEndpoint asserts that when OTEL_EXPORTER_OTLP_ENDPOINT is unset
+// (the default in tests),
+// Setup installs propagators, returns a non-nil no-op shutdown,
+// and never touches the network.
+func TestSetup_NoEndpoint(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+
+	shutdown, err := Setup(context.Background(), "test-service", "v0.0.0")
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+
+	// Composite W3C propagator should be installed even in no-op mode.
+	prop := otel.GetTextMapPropagator()
+	require.NotNil(t, prop)
+	assert.Contains(t, prop.Fields(), "traceparent")
+
+	// Shutdown is a no-op and must not error.
+	require.NoError(t, shutdown(context.Background()))
+}

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -3,10 +3,17 @@ package telemetry
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
 // TestSetup_NoEndpoint asserts that when OTEL_EXPORTER_OTLP_ENDPOINT is unset
@@ -27,4 +34,108 @@ func TestSetup_NoEndpoint(t *testing.T) {
 
 	// Shutdown is a no-op and must not error.
 	require.NoError(t, shutdown(context.Background()))
+}
+
+// TestSetup_WithEndpoint asserts that with OTEL_EXPORTER_OTLP_ENDPOINT set,
+// Setup installs real SDK providers instead of the default no-ops.
+func TestSetup_WithEndpoint(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+	// Short exporter timeout so the shutdown flush fails fast when nothing is listening.
+	t.Setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "100")
+	t.Cleanup(resetGlobalProviders)
+
+	shutdown, err := Setup(context.Background(), "test-service", "v0.0.0")
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+
+	assert.IsType(t, &sdktrace.TracerProvider{}, otel.GetTracerProvider())
+	assert.IsType(t, &sdkmetric.MeterProvider{}, otel.GetMeterProvider())
+
+	// The endpoint is unreachable, so the flush will fail. That is fine here.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_ = shutdown(shutdownCtx)
+}
+
+// TestBuildResource_ServiceAttrs checks that service.name and service.version end up on the resource.
+func TestBuildResource_ServiceAttrs(t *testing.T) {
+	// Clear inherited env to keep the test deterministic.
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+
+	res, err := buildResource(context.Background(), "svc-under-test", "v1.2.3")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	attrs := attributesAsMap(res.Attributes())
+	assert.Equal(t, "svc-under-test", attrs[string(semconv.ServiceNameKey)])
+	assert.Equal(t, "v1.2.3", attrs[string(semconv.ServiceVersionKey)])
+}
+
+// TestBuildResource_IncludesDownwardAPI checks that each K8S_* env var lands on the resource under its OTel key.
+func TestBuildResource_IncludesDownwardAPI(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("K8S_POD_NAME", "pod-1")
+	t.Setenv("K8S_POD_NAMESPACE", "sbomscanner")
+	t.Setenv("K8S_NODE_NAME", "node-a")
+	t.Setenv("K8S_POD_UID", "uid-123")
+	t.Setenv("K8S_CONTAINER_NAME", "controller")
+
+	res, err := buildResource(context.Background(), "svc", "v0")
+	require.NoError(t, err)
+
+	attrs := attributesAsMap(res.Attributes())
+	assert.Equal(t, "pod-1", attrs[string(semconv.K8SPodNameKey)])
+	assert.Equal(t, "sbomscanner", attrs[string(semconv.K8SNamespaceNameKey)])
+	assert.Equal(t, "node-a", attrs[string(semconv.K8SNodeNameKey)])
+	assert.Equal(t, "uid-123", attrs[string(semconv.K8SPodUIDKey)])
+	assert.Equal(t, "controller", attrs[string(semconv.K8SContainerNameKey)])
+}
+
+// TestBuildResource_SkipsEmptyDownwardAPI checks that empty K8S_* env vars are not added as empty attributes.
+func TestBuildResource_SkipsEmptyDownwardAPI(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	for _, e := range downwardAPIEnv {
+		t.Setenv(e.env, "")
+	}
+
+	res, err := buildResource(context.Background(), "svc", "v0")
+	require.NoError(t, err)
+
+	attrs := attributesAsMap(res.Attributes())
+	for _, e := range downwardAPIEnv {
+		assert.NotContains(t, attrs, string(e.key))
+	}
+}
+
+// TestBuildResource_PartialFromMalformedEnv checks that a malformed OTEL_RESOURCE_ATTRIBUTES value still yields a resource with the good pairs.
+func TestBuildResource_PartialFromMalformedEnv(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "good.key=good-value,malformed-no-equals")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+
+	res, err := buildResource(context.Background(), "svc", "v0")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	attrs := attributesAsMap(res.Attributes())
+	assert.Equal(t, "good-value", attrs["good.key"])
+	assert.Equal(t, "svc", attrs[string(semconv.ServiceNameKey)])
+}
+
+// attributesAsMap turns an attribute slice into a plain string map for easier assertions.
+func attributesAsMap(attrs []attribute.KeyValue) map[string]string {
+	out := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		out[string(kv.Key)] = kv.Value.Emit()
+	}
+	return out
+}
+
+// resetGlobalProviders returns the process-global TracerProvider and MeterProvider to explicit no-op implementations,
+// preventing an SDK provider installed by one test from leaking into others.
+func resetGlobalProviders() {
+	otel.SetTracerProvider(tracenoop.NewTracerProvider())
+	otel.SetMeterProvider(metricnoop.NewMeterProvider())
 }

--- a/internal/telemetry/scope.go
+++ b/internal/telemetry/scope.go
@@ -1,0 +1,35 @@
+package telemetry
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/kubewarden/sbomscanner/internal/version"
+)
+
+// moduleRoot is the Go module path of this repository.
+// It is the prefix added to every instrumentation scope,
+// so the wire format stays spec-conformant (full import path) even though call sites pass a short, repo-relative name.
+const moduleRoot = "github.com/kubewarden/sbomscanner"
+
+// Tracer returns a trace.Tracer whose instrumentation scope is moduleRoot joined with pkgPath,
+// and whose instrumentation version is internal/version.Version.
+// pkgPath is the repo-relative directory of the calling package (e.g. "internal/handlers"); "" scopes at the module root.
+func Tracer(pkgPath string) trace.Tracer {
+	return otel.Tracer(scopeName(pkgPath), trace.WithInstrumentationVersion(version.Version))
+}
+
+// Meter returns a metric.Meter whose instrumentation scope is moduleRoot joined with pkgPath,
+// and whose instrumentation version is internal/version.Version.
+// pkgPath is the repo-relative directory of the calling package (e.g. "internal/handlers"); "" scopes at the module root.
+func Meter(pkgPath string) metric.Meter {
+	return otel.Meter(scopeName(pkgPath), metric.WithInstrumentationVersion(version.Version))
+}
+
+func scopeName(pkgPath string) string {
+	if pkgPath == "" {
+		return moduleRoot
+	}
+	return moduleRoot + "/" + pkgPath
+}

--- a/internal/telemetry/scope_test.go
+++ b/internal/telemetry/scope_test.go
@@ -1,0 +1,28 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestScopeName_Empty returns the bare module root,
+// so callers that don't want a sub-scope get the project-level identifier.
+func TestScopeName_Empty(t *testing.T) {
+	assert.Equal(t, "github.com/kubewarden/sbomscanner", scopeName(""))
+}
+
+// TestScopeName_PkgPath prefixes the module root onto the repo-relative path,
+// producing the full Go import path expected by the OTel spec.
+func TestScopeName_PkgPath(t *testing.T) {
+	assert.Equal(t, "github.com/kubewarden/sbomscanner/internal/handlers", scopeName("internal/handlers"))
+}
+
+// TestTracerMeter_NonNil simply checks that the helpers wire up without panicking,
+// and return non-nil providers under the default global no-op SDK.
+func TestTracerMeter_NonNil(t *testing.T) {
+	assert.NotNil(t, Tracer(""))
+	assert.NotNil(t, Tracer("internal/handlers"))
+	assert.NotNil(t, Meter(""))
+	assert.NotNil(t, Meter("internal/handlers"))
+}

--- a/internal/telemetry/slog.go
+++ b/internal/telemetry/slog.go
@@ -1,0 +1,68 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Attribute keys used to decorate slog records with the active span identifiers.
+const (
+	traceIDKey = "trace_id"
+	spanIDKey  = "span_id"
+)
+
+// traceContextHandler wraps a [slog.Handler] and decorates every record with the active span's trace_id and span_id,
+// when the record's context carries one.
+//
+// When no span is active, the handler is a transparent pass-through.
+type traceContextHandler struct {
+	inner slog.Handler
+}
+
+// NewTraceContextHandler wraps handler so that records emitted with a context-carrying SpanContext are annotated with `trace_id` and `span_id` fields.
+// The wrapper preserves group/attribute behaviour of the inner handler.
+func NewTraceContextHandler(handler slog.Handler) slog.Handler {
+	if handler == nil {
+		return nil
+	}
+	if _, ok := handler.(*traceContextHandler); ok {
+		// Already wrapped, avoid stacking.
+		return handler
+	}
+	return &traceContextHandler{inner: handler}
+}
+
+// Enabled reports whether the inner handler is enabled for the given level.
+func (h *traceContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+// Handle adds trace_id and span_id attributes to record when ctx carries a valid SpanContext,
+// then delegates to the inner handler.
+// The record is cloned before mutation so downstream handlers (or future fan-out wrappers) never see attrs leaked from a shared backing array.
+func (h *traceContextHandler) Handle(ctx context.Context, record slog.Record) error {
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		record = record.Clone()
+		record.AddAttrs(
+			slog.String(traceIDKey, sc.TraceID().String()),
+			slog.String(spanIDKey, sc.SpanID().String()),
+		)
+	}
+	if err := h.inner.Handle(ctx, record); err != nil {
+		return fmt.Errorf("inner slog handler: %w", err)
+	}
+	return nil
+}
+
+// WithAttrs returns a new traceContextHandler wrapping the inner handler with attrs applied.
+func (h *traceContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &traceContextHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+// WithGroup returns a new traceContextHandler wrapping the inner handler with the given group name.
+func (h *traceContextHandler) WithGroup(name string) slog.Handler {
+	return &traceContextHandler{inner: h.inner.WithGroup(name)}
+}

--- a/internal/telemetry/slog_test.go
+++ b/internal/telemetry/slog_test.go
@@ -1,0 +1,66 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// TestTraceContextHandler_InjectsIDs verifies that trace_id/span_id are added to log records,
+// when a span is active in the record's context.
+func TestTraceContextHandler_InjectsIDs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewTraceContextHandler(slog.NewJSONHandler(&buf, nil)))
+
+	// Use a real (in-memory) SDK tracer so SpanContext is valid.
+	tracerProvider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tracerProvider.Shutdown(context.Background()) })
+
+	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "op")
+	defer span.End()
+
+	logger.InfoContext(ctx, "hello")
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &record))
+
+	assert.Equal(t, span.SpanContext().TraceID().String(), record[traceIDKey])
+	assert.Equal(t, span.SpanContext().SpanID().String(), record[spanIDKey])
+	assert.Equal(t, "hello", record["msg"])
+}
+
+// TestTraceContextHandler_NoSpan asserts the wrapper is a transparent pass-through,
+// when no span is in the context.
+func TestTraceContextHandler_NoSpan(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewTraceContextHandler(slog.NewJSONHandler(&buf, nil)))
+
+	logger.Info("plain")
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &record))
+	assert.NotContains(t, record, traceIDKey, "trace_id should be absent when no span")
+	assert.NotContains(t, record, spanIDKey, "span_id should be absent when no span")
+}
+
+// TestNewTraceContextHandler_NilInput returns nil for a nil inner handler,
+// so callers can chain it unconditionally.
+func TestNewTraceContextHandler_NilInput(t *testing.T) {
+	assert.Nil(t, NewTraceContextHandler(nil))
+}
+
+// TestNewTraceContextHandler_AvoidsStacking returns the same handler when called twice,
+// to prevent N-layer wrappers in code that defensively re-wraps.
+func TestNewTraceContextHandler_AvoidsStacking(t *testing.T) {
+	inner := slog.NewJSONHandler(&bytes.Buffer{}, nil)
+	once := NewTraceContextHandler(inner)
+	twice := NewTraceContextHandler(once)
+
+	assert.Same(t, once, twice)
+}

--- a/internal/version/doc.go
+++ b/internal/version/doc.go
@@ -1,0 +1,2 @@
+// Package version exposes the build version embedded into sbomscanner binaries.
+package version

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the human-readable build version.
+var Version = "dev"


### PR DESCRIPTION
## Description

Introduces the shared OpenTelemetry bootstrap for the four sbomscanner binaries, gated on `OTEL_EXPORTER_OTLP_ENDPOINT`. 

When the variable is unset, the binaries install no-op providers and behave exactly as before; when it is set, traces and metrics are exported over OTLP/gRPC to any collector the operator provides.
All runtime configuration is done via the standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/); no new CLI flags are introduced.

The new `internal/telemetry` package holds the `Setup` entry point, an `slog.Handler` wrapper that decorates log records with the active `trace_id` and `span_id` for log-to-trace correlation, a `TextMapCarrier` over NATS headers used by the messaging layer, and small `Tracer` / `Meter` helpers that expose the spec-conformant instrumentation scope. 

Each `cmd/*/main.go` now calls `telemetry.Setup` right after slog init and defers a bounded shutdown. 

Also, it adds build-time version injecitonm, which is used as metadata in the telemetry.

Fixes #1215 