### PR TITLE
fix: mark NodeScanJob as failed when referenced Node is missing

### DIFF
--- a/api/v1alpha1/nodescanjob_types.go
+++ b/api/v1alpha1/nodescanjob_types.go
@@ -32,6 +32,7 @@ const (
 const (
 	ReasonNodeScanJobInProgress               = "InProgress"
 	ReasonNodeScanJobConfigurationMissing     = "NodeScanConfigurationMissing"
+	ReasonNodeScanJobNodeNotFound             = "NodeNotFound"
 	ReasonNodeScanJobNotMatching              = "NodeNotMatching"
 	ReasonNodeScanJobPending                  = "Pending"
 	ReasonNodeScanJobSBOMGenerationInProgress = "SBOMGenerationInProgress"

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -160,7 +160,7 @@ func main() {
 	case nodeMode:
 		scanMode = messaging.HandlerRegistry{
 			handlers.GenerateNodeSBOMSubject + "." + nodeName: handlers.NewGenerateNodeSBOMHandler(k8sClient, scheme, runDir, targetDir, trivyJavaDBRepository, publisher, installationNamespace, logger),
-			handlers.ScanNodeSBOMSubject + "." + nodeName:     handlers.NewScanNodeSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, logger),
+			handlers.ScanNodeSBOMSubject + "." + nodeName:     handlers.NewNodeScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, logger),
 		}
 		durableName = "worker-node-" + nodeName
 	default:

--- a/internal/controller/nodescanjob_controller.go
+++ b/internal/controller/nodescanjob_controller.go
@@ -15,7 +15,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
@@ -54,18 +53,6 @@ func (r *NodeScanJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	var node corev1.Node
-	if err := r.Get(ctx, types.NamespacedName{Name: nodeScanJob.Spec.NodeName}, &node); err != nil {
-		if errors.IsNotFound(err) {
-			log.Info("Node no longer exists, deleting NodeScanJob", "nodeScanJob", req.NamespacedName, "nodeName", nodeScanJob.Spec.NodeName)
-			if delErr := r.Delete(ctx, nodeScanJob); delErr != nil && !errors.IsNotFound(delErr) {
-				return ctrl.Result{}, fmt.Errorf("failed to delete NodeScanJob for missing node: %w", delErr)
-			}
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to check if node %s exists: %w", nodeScanJob.Spec.NodeName, err)
-	}
-
 	if !nodeScanJob.IsPending() {
 		log.V(1).Info("NodeScanJob is not in pending state, skipping reconciliation", "nodeScanJob", req.NamespacedName)
 		return ctrl.Result{}, nil
@@ -73,8 +60,7 @@ func (r *NodeScanJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	nodeScanJob.InitializeConditions()
 
-	var valid bool
-	valid, err := r.validateNodeAgainstConfig(ctx, nodeScanJob, &node)
+	valid, err := r.validateNodeAgainstConfig(ctx, nodeScanJob)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -97,8 +83,9 @@ func (r *NodeScanJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 // validateNodeAgainstConfig checks the NodeScanConfiguration exists and
-// the node matches it. Returns (true, nil) when the node is valid.
-func (r *NodeScanJobReconciler) validateNodeAgainstConfig(ctx context.Context, job *v1alpha1.NodeScanJob, node *corev1.Node) (bool, error) {
+// the node referenced by the job exists and matches the configuration.
+// Returns (true, nil) when the node is valid.
+func (r *NodeScanJobReconciler) validateNodeAgainstConfig(ctx context.Context, job *v1alpha1.NodeScanJob) (bool, error) {
 	log := logf.FromContext(ctx)
 
 	var config v1alpha1.NodeScanConfiguration
@@ -109,6 +96,18 @@ func (r *NodeScanJobReconciler) validateNodeAgainstConfig(ctx context.Context, j
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to get NodeScanConfiguration: %w", err)
+	}
+
+	var node corev1.Node
+	if err := r.Get(ctx, types.NamespacedName{Name: job.Spec.NodeName}, &node); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Node not found, marking NodeScanJob as failed",
+				"nodeScanJob", job.Name, "nodeName", job.Spec.NodeName)
+			job.MarkFailed(v1alpha1.ReasonNodeScanJobNodeNotFound,
+				fmt.Sprintf("Node %s not found", job.Spec.NodeName))
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check if node %s exists: %w", job.Spec.NodeName, err)
 	}
 
 	if config.Spec.NodeSelector != nil {
@@ -221,36 +220,10 @@ func (r *NodeScanJobReconciler) cleanupOldNodeScanJobs(ctx context.Context, curr
 	return nil
 }
 
-func (r *NodeScanJobReconciler) mapNodeToNodeScanJobs(ctx context.Context, obj client.Object) []ctrl.Request {
-	log := logf.FromContext(ctx)
-
-	var nodeScanJobs v1alpha1.NodeScanJobList
-	if err := r.List(ctx, &nodeScanJobs,
-		client.MatchingFields{v1alpha1.IndexNodeScanJobSpecNodeName: obj.GetName()},
-	); err != nil {
-		log.Error(err, "Failed to list NodeScanJobs for node", "node", obj.GetName())
-		return nil
-	}
-
-	requests := make([]ctrl.Request, 0, len(nodeScanJobs.Items))
-	for i := range nodeScanJobs.Items {
-		requests = append(requests, ctrl.Request{
-			NamespacedName: types.NamespacedName{
-				Name: nodeScanJobs.Items[i].Name,
-			},
-		})
-	}
-
-	return requests
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.NodeScanJob{}).
-		Watches(&corev1.Node{},
-			handler.EnqueueRequestsFromMapFunc(r.mapNodeToNodeScanJobs),
-		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,
 		}).

--- a/internal/controller/nodescanjob_controller_test.go
+++ b/internal/controller/nodescanjob_controller_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
@@ -314,6 +314,7 @@ var _ = Describe("NodeScanJob Controller", func() {
 	When("A NodeScanJob is created for an invalid Node", func() {
 		var reconciler NodeScanJobReconciler
 		var nodeScanJob v1alpha1.NodeScanJob
+		var config v1alpha1.NodeScanConfiguration
 		var mockPublisher *messagingMocks.MockPublisher
 
 		BeforeEach(func(ctx context.Context) {
@@ -324,6 +325,15 @@ var _ = Describe("NodeScanJob Controller", func() {
 				Publisher: mockPublisher,
 				Scheme:    k8sClient.Scheme(),
 			}
+
+			By("Creating a NodeScanConfiguration")
+			config = v1alpha1.NodeScanConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.NodeScanConfigurationName,
+				},
+				Spec: v1alpha1.NodeScanConfigurationSpec{},
+			}
+			Expect(k8sClient.Create(ctx, &config)).To(Succeed())
 
 			By("Creating a NodeScanJob referencing a non-existent node")
 			nodeScanJob = v1alpha1.NodeScanJob{
@@ -337,7 +347,11 @@ var _ = Describe("NodeScanJob Controller", func() {
 			Expect(k8sClient.Create(ctx, &nodeScanJob)).To(Succeed())
 		})
 
-		It("should delete the NodeScanJob when the node no longer exists", func(ctx context.Context) {
+		AfterEach(func(ctx context.Context) {
+			Expect(k8sClient.Delete(ctx, &config)).To(Succeed())
+		})
+
+		It("should mark the NodeScanJob as failed with NodeNotFound reason", func(ctx context.Context) {
 			By("Reconciling the NodeScanJob")
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -346,13 +360,17 @@ var _ = Describe("NodeScanJob Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Verifying the NodeScanJob was deleted")
-			deletedJob := &v1alpha1.NodeScanJob{}
+			By("Verifying the NodeScanJob still exists and is marked as failed with NodeNotFound")
+			updatedJob := &v1alpha1.NodeScanJob{}
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name: nodeScanJob.Name,
-			}, deletedJob)
-			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
-			Expect(deletedJob.Name).To(BeEmpty())
+			}, updatedJob)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedJob.IsFailed()).To(BeTrue())
+
+			failedCond := meta.FindStatusCondition(updatedJob.Status.Conditions, v1alpha1.ConditionNodeScanJobTypeFailed)
+			Expect(failedCond).NotTo(BeNil())
+			Expect(failedCond.Reason).To(Equal(v1alpha1.ReasonNodeScanJobNodeNotFound))
 		})
 	})
 })

--- a/internal/handlers/generate_node_sbom.go
+++ b/internal/handlers/generate_node_sbom.go
@@ -125,6 +125,11 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 		return h.k8sClient.Status().Update(ctx, nodeScanJob)
 	})
 	if err != nil {
+		// The NodeScanJob may have been deleted while we were processing; abandon the update.
+		if apierrors.IsNotFound(err) {
+			h.logger.InfoContext(ctx, "NodeScanJob not found, stopping NodeSBOM generation", "nodescanjob", generateNodeSBOMMessage.NodeScanJob.Name)
+			return nil
+		}
 		return fmt.Errorf("failed to update NodeScanJob status to in progress: %w", err)
 	}
 
@@ -176,6 +181,15 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 	})
 	if err != nil {
 		return fmt.Errorf("cannot marshal scan NodeSBOM message: %w", err)
+	}
+
+	// The NodeScanJob may have been deleted while we were processing; abandon the update.
+	if err = h.k8sClient.Get(ctx, client.ObjectKey{Name: generateNodeSBOMMessage.NodeScanJob.Name}, &v1alpha1.NodeScanJob{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			h.logger.InfoContext(ctx, "NodeScanJob no longer exists, skipping publish of scan NodeSBOM message", "nodescanjob", generateNodeSBOMMessage.NodeScanJob.Name)
+			return nil
+		}
+		return fmt.Errorf("cannot get NodeScanJob %s: %w", generateNodeSBOMMessage.NodeScanJob.Name, err)
 	}
 
 	if err = h.publisher.Publish(ctx, ScanNodeSBOMSubject+"."+nodeScanJob.Spec.NodeName, scanNodeSBOMMessageID, scanNodeSBOMMessage); err != nil {

--- a/internal/handlers/generate_node_sbom.go
+++ b/internal/handlers/generate_node_sbom.go
@@ -64,7 +64,7 @@ func NewGenerateNodeSBOMHandler(
 
 // Handle processes the GenerateNodeSBOMMessage and generates a SBOM resource from the specified image.
 //
-//nolint:funlen // This function is responsible for orchestrating multiple steps in the SBOM generation process, making it inherently complex and lengthy.
+//nolint:funlen,gocognit // This function is responsible for orchestrating multiple steps in the SBOM generation process, making it inherently complex and lengthy.
 func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.Message) error {
 	generateNodeSBOMMessage := &GenerateNodeSBOMMessage{}
 	if err := json.Unmarshal(message.Data(), generateNodeSBOMMessage); err != nil {

--- a/internal/handlers/node_scan_sbom.go
+++ b/internal/handlers/node_scan_sbom.go
@@ -46,7 +46,7 @@ func NewNodeScanSBOMHandler(
 	}
 }
 
-//nolint:funlen
+//nolint:funlen,gocognit // This function is responsible for orchestrating multiple steps in the node SBOM scanning process, making it inherently complex and lengthy.
 func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Message) error {
 	scanNodeSBOMMessage := &ScanNodeSBOMMessage{}
 	if err := json.Unmarshal(message.Data(), scanNodeSBOMMessage); err != nil {

--- a/internal/handlers/node_scan_sbom.go
+++ b/internal/handlers/node_scan_sbom.go
@@ -100,6 +100,11 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 		return h.k8sClient.Status().Update(ctx, scanJob)
 	})
 	if err != nil {
+		// The NodeScanJob may have been deleted while we were processing; abandon the update.
+		if apierrors.IsNotFound(err) {
+			h.logger.InfoContext(ctx, "NodeScanJob not found, stopping SBOM scan", "scanjob", nodeScanJobName, "namespace", nodeScanJobNamespace)
+			return nil
+		}
 		return fmt.Errorf("failed to update NodeScanJob status to SBOM generation in progress: %w", err)
 	}
 
@@ -171,6 +176,11 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 		return h.k8sClient.Status().Update(ctx, scanJob)
 	})
 	if err != nil {
+		// The NodeScanJob may have been deleted while we were processing; abandon the update.
+		if apierrors.IsNotFound(err) {
+			h.logger.InfoContext(ctx, "NodeScanJob not found, skipping completion update", "scanjob", nodeScanJobName, "namespace", nodeScanJobNamespace)
+			return nil
+		}
 		return fmt.Errorf("failed to update NodeScanJob status: %w", err)
 	}
 	h.logger.InfoContext(ctx, "NodeSBOM scanned",

--- a/internal/handlers/node_scan_sbom.go
+++ b/internal/handlers/node_scan_sbom.go
@@ -25,8 +25,8 @@ type NodeScanSBOMHandler struct {
 	scanSBOMBase
 }
 
-// NewScanNodeSBOMHandler creates a new instance of NodeScanSBOMHandler for nodes.
-func NewScanNodeSBOMHandler(
+// NewNodeScanSBOMHandler creates a new instance of NodeScanSBOMHandler for nodes.
+func NewNodeScanSBOMHandler(
 	k8sClient client.Client,
 	scheme *runtime.Scheme,
 	workDir string,

--- a/internal/handlers/node_scan_sbom_test.go
+++ b/internal/handlers/node_scan_sbom_test.go
@@ -1,0 +1,200 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	_ "modernc.org/sqlite"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubewarden/sbomscanner/api"
+	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
+	"github.com/kubewarden/sbomscanner/api/v1alpha1"
+)
+
+func TestNodeScanSBOMHandler_Handle(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	spdxData, err := os.ReadFile(filepath.Join("..", "..", "test", "fixtures", "golang-1.12-alpine-amd64.spdx.json"))
+	require.NoError(t, err)
+
+	nodeScanJob := &v1alpha1.NodeScanJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-nodescanjob",
+			UID:  "test-nodescanjob-uid",
+		},
+		Spec: v1alpha1.NodeScanJobSpec{
+			NodeName: "test-node",
+		},
+	}
+
+	nodeSBOM := &storagev1alpha1.NodeSBOM{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			UID:  "test-nodesbom-uid",
+		},
+		NodeMetadata: storagev1alpha1.NodeMetadata{
+			Name:     "test-node",
+			Platform: "linux/amd64",
+		},
+		SPDX: runtime.RawExtension{Raw: spdxData},
+	}
+
+	vexHubs := &v1alpha1.VEXHubList{
+		Items: []v1alpha1.VEXHub{},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, storagev1alpha1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(nodeScanJob, nodeSBOM, vexHubs).
+		WithStatusSubresource(&v1alpha1.NodeScanJob{}).
+		Build()
+
+	handler := NewScanNodeSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+
+	message, err := json.Marshal(&ScanNodeSBOMMessage{
+		NodeBaseMessage: NodeBaseMessage{
+			NodeScanJob: ObjectRef{
+				Name: nodeScanJob.Name,
+				UID:  string(nodeScanJob.UID),
+			},
+		},
+		NodeSBOM: ObjectRef{
+			Name: nodeSBOM.Name,
+		},
+	})
+	require.NoError(t, err)
+
+	err = handler.Handle(t.Context(), &testMessage{data: message})
+	require.NoError(t, err)
+
+	report := &storagev1alpha1.NodeVulnerabilityReport{}
+	err = k8sClient.Get(t.Context(), types.NamespacedName{Name: nodeSBOM.Name}, report)
+	require.NoError(t, err)
+
+	assert.Equal(t, nodeSBOM.NodeMetadata, report.NodeMetadata)
+	assert.Equal(t, string(nodeScanJob.UID), report.Labels[v1alpha1.LabelNodeScanJobUIDKey])
+	assert.Equal(t, api.LabelManagedByValue, report.Labels[api.LabelManagedByKey])
+	assert.Equal(t, api.LabelPartOfValue, report.Labels[api.LabelPartOfKey])
+	assert.Equal(t, nodeSBOM.UID, report.GetOwnerReferences()[0].UID)
+	assert.NotEmpty(t, report.Report.Results)
+
+	updatedJob := &v1alpha1.NodeScanJob{}
+	err = k8sClient.Get(t.Context(), types.NamespacedName{Name: nodeScanJob.Name}, updatedJob)
+	require.NoError(t, err)
+	assert.True(t, updatedJob.IsComplete())
+}
+
+func TestNodeScanSBOMHandler_Handle_StopProcessing(t *testing.T) {
+	spdxData, err := os.ReadFile(filepath.Join("..", "..", "test", "fixtures", "golang-1.12-alpine-amd64.spdx.json"))
+	require.NoError(t, err)
+
+	nodeSBOM := &storagev1alpha1.NodeSBOM{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		NodeMetadata: storagev1alpha1.NodeMetadata{
+			Name:     "test-node",
+			Platform: "linux/amd64",
+		},
+		SPDX: runtime.RawExtension{Raw: spdxData},
+	}
+
+	vexHubs := &v1alpha1.VEXHubList{
+		Items: []v1alpha1.VEXHub{},
+	}
+
+	nodeScanJob := &v1alpha1.NodeScanJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-nodescanjob",
+			UID:  "test-nodescanjob-uid",
+		},
+		Spec: v1alpha1.NodeScanJobSpec{
+			NodeName: "test-node",
+		},
+	}
+
+	differentUIDNodeScanJob := nodeScanJob.DeepCopy()
+	differentUIDNodeScanJob.UID = "test-nodescanjob-different-uid"
+
+	failedNodeScanJob := nodeScanJob.DeepCopy()
+	failedNodeScanJob.MarkFailed(v1alpha1.ReasonScanJobInternalError, "kaboom")
+
+	tests := []struct {
+		name            string
+		nodeScanJob     *v1alpha1.NodeScanJob
+		existingObjects []runtime.Object
+	}{
+		{
+			name:            "nodescanjob not found",
+			nodeScanJob:     nodeScanJob,
+			existingObjects: []runtime.Object{nodeSBOM, vexHubs},
+		},
+		{
+			name:            "nodescanjob was recreated with different UID",
+			nodeScanJob:     nodeScanJob,
+			existingObjects: []runtime.Object{differentUIDNodeScanJob, nodeSBOM, vexHubs},
+		},
+		{
+			name:            "nodescanjob is failed",
+			nodeScanJob:     failedNodeScanJob,
+			existingObjects: []runtime.Object{failedNodeScanJob, nodeSBOM, vexHubs},
+		},
+		{
+			name:            "nodesbom not found",
+			nodeScanJob:     nodeScanJob,
+			existingObjects: []runtime.Object{nodeScanJob, vexHubs},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, storagev1alpha1.AddToScheme(scheme))
+			require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(test.existingObjects...).
+				WithStatusSubresource(&v1alpha1.NodeScanJob{}).
+				Build()
+
+			cacheDir := t.TempDir()
+			handler := NewScanNodeSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+
+			message, err := json.Marshal(&ScanNodeSBOMMessage{
+				NodeBaseMessage: NodeBaseMessage{
+					NodeScanJob: ObjectRef{
+						Name: test.nodeScanJob.Name,
+						UID:  string(test.nodeScanJob.UID),
+					},
+				},
+				NodeSBOM: ObjectRef{
+					Name: nodeSBOM.Name,
+				},
+			})
+			require.NoError(t, err)
+
+			err = handler.Handle(context.Background(), &testMessage{data: message})
+			require.NoError(t, err)
+
+			report := &storagev1alpha1.NodeVulnerabilityReport{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: nodeSBOM.Name}, report)
+			assert.True(t, apierrors.IsNotFound(err), "NodeVulnerabilityReport should not exist")
+		})
+	}
+}

--- a/internal/handlers/node_scan_sbom_test.go
+++ b/internal/handlers/node_scan_sbom_test.go
@@ -64,7 +64,7 @@ func TestNodeScanSBOMHandler_Handle(t *testing.T) {
 		WithStatusSubresource(&v1alpha1.NodeScanJob{}).
 		Build()
 
-	handler := NewScanNodeSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+	handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
 
 	message, err := json.Marshal(&ScanNodeSBOMMessage{
 		NodeBaseMessage: NodeBaseMessage{
@@ -174,7 +174,7 @@ func TestNodeScanSBOMHandler_Handle_StopProcessing(t *testing.T) {
 				Build()
 
 			cacheDir := t.TempDir()
-			handler := NewScanNodeSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+			handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
 
 			message, err := json.Marshal(&ScanNodeSBOMMessage{
 				NodeBaseMessage: NodeBaseMessage{

--- a/internal/handlers/nodescanjob_failure_test.go
+++ b/internal/handlers/nodescanjob_failure_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubewarden/sbomscanner/api/v1alpha1"
+)
+
+func TestNodeScanJobFailureHandler_HandleFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	nodeScanJob := &v1alpha1.NodeScanJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-nodescanjob",
+		},
+		Spec: v1alpha1.NodeScanJobSpec{
+			NodeName: "test-node",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(nodeScanJob).
+		WithStatusSubresource(nodeScanJob).
+		Build()
+
+	handler := NewNodeScanJobFailureHandler(k8sClient, slog.Default())
+
+	message, err := json.Marshal(&GenerateNodeSBOMMessage{
+		NodeBaseMessage: NodeBaseMessage{
+			NodeScanJob: ObjectRef{
+				Name: nodeScanJob.Name,
+			},
+		},
+		Node: ObjectRef{
+			Name: "test-node",
+		},
+	})
+	require.NoError(t, err)
+
+	errorMessage := "NodeSBOM generation failed"
+	err = handler.HandleFailure(t.Context(), &testMessage{data: message}, errorMessage)
+	require.NoError(t, err)
+
+	updatedJob := &v1alpha1.NodeScanJob{}
+	err = k8sClient.Get(t.Context(), types.NamespacedName{Name: nodeScanJob.Name}, updatedJob)
+	require.NoError(t, err)
+
+	assert.True(t, updatedJob.IsFailed())
+	failedCondition := meta.FindStatusCondition(updatedJob.Status.Conditions, v1alpha1.ConditionNodeScanJobTypeFailed)
+	require.NotNil(t, failedCondition)
+	assert.Equal(t, v1alpha1.ReasonScanJobInternalError, failedCondition.Reason)
+	assert.Equal(t, errorMessage, failedCondition.Message)
+}
+
+func TestNodeScanJobFailureHandler_HandleFailure_NodeScanJobNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	handler := NewNodeScanJobFailureHandler(k8sClient, slog.Default())
+
+	message, err := json.Marshal(&GenerateNodeSBOMMessage{
+		NodeBaseMessage: NodeBaseMessage{
+			NodeScanJob: ObjectRef{
+				Name: "missing-nodescanjob",
+			},
+		},
+		Node: ObjectRef{
+			Name: "test-node",
+		},
+	})
+	require.NoError(t, err)
+
+	err = handler.HandleFailure(t.Context(), &testMessage{data: message}, "kaboom")
+	require.NoError(t, err)
+
+	job := &v1alpha1.NodeScanJob{}
+	err = k8sClient.Get(t.Context(), types.NamespacedName{Name: "missing-nodescanjob"}, job)
+	assert.True(t, apierrors.IsNotFound(err))
+}

--- a/internal/handlers/scan_sbom.go
+++ b/internal/handlers/scan_sbom.go
@@ -19,12 +19,12 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/messaging"
 )
 
-// ImageScanSBOMHandler handles SBOM scan requests for container images.
-type ImageScanSBOMHandler struct {
+// ScanSBOMHandler is responsible for handling SBOM scan requests.
+type ScanSBOMHandler struct {
 	scanSBOMBase
 }
 
-// NewScanSBOMHandler creates a new instance of ImageScanSBOMHandler for container images.
+// NewScanSBOMHandler creates a new instance of ScanSBOMHandler.
 func NewScanSBOMHandler(
 	k8sClient client.Client,
 	scheme *runtime.Scheme,
@@ -32,8 +32,8 @@ func NewScanSBOMHandler(
 	trivyDBRepository string,
 	trivyJavaDBRepository string,
 	logger *slog.Logger,
-) *ImageScanSBOMHandler {
-	return &ImageScanSBOMHandler{
+) *ScanSBOMHandler {
+	return &ScanSBOMHandler{
 		scanSBOMBase: scanSBOMBase{
 			k8sClient:             k8sClient,
 			scheme:                scheme,
@@ -46,7 +46,7 @@ func NewScanSBOMHandler(
 }
 
 //nolint:funlen
-func (h *ImageScanSBOMHandler) Handle(ctx context.Context, message messaging.Message) error {
+func (h *ScanSBOMHandler) Handle(ctx context.Context, message messaging.Message) error {
 	scanSBOMMessage := &ScanSBOMMessage{}
 	if err := json.Unmarshal(message.Data(), scanSBOMMessage); err != nil {
 		return fmt.Errorf("failed to unmarshal scan job message: %w", err)


### PR DESCRIPTION
## Description

  - When the node referenced by a `NodeScanJob` no longer exists, the job is now marked as failed with a `NodeNotFound` reason instead of being silently deleted. This matches how the controller already handles other missing dependencies (e.g. a missing registry for a regular scan job).
  - Moved the node existence check into the same validation function that already verifies the configuration and node selectors, so all preconditions are checked in one place.
  - The node scan workers now stop cleanly if the job they are working on gets deleted mid-flight. Previously a deletion during processing could surface as a hard error and cause the message to be retried needlessly.
  - Before publishing the follow-up scan message, the SBOM generator now checks that the job still exists, so we don't kick off a vulnerability scan for work that has already been cancelled.
  - Added missing tests.