### PR TITLE
feat(controller): add enabled/disabled to NodeScanConfiguration

### DIFF
--- a/api/v1alpha1/nodescanconfiguration_types.go
+++ b/api/v1alpha1/nodescanconfiguration_types.go
@@ -15,6 +15,9 @@ const (
 
 // NodeScanConfigurationSpec defines the desired configuration for node scanning.
 type NodeScanConfigurationSpec struct {
+	// Enabled controls whether node scanning is active.
+	// +kubebuilder:default=true
+	Enabled bool `json:"enabled"`
 	// NodeSelector filters which nodes are scanned.
 	// If not specified, all the nodes are scanned.
 	// +optional

--- a/charts/sbomscanner/templates/controller/role.yaml
+++ b/charts/sbomscanner/templates/controller/role.yaml
@@ -56,6 +56,18 @@ rules:
   - sbomscanner.kubewarden.io
   resources:
   - nodescanjobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sbomscanner.kubewarden.io
+  resources:
   - registries
   - scanjobs
   verbs:
@@ -89,6 +101,7 @@ rules:
   - nodesboms
   verbs:
   - delete
+  - deletecollection
   - list
   - watch
 - apiGroups:

--- a/charts/sbomscanner/templates/crd/sbomscanner.kubewarden.io_nodescanconfigurations.yaml
+++ b/charts/sbomscanner/templates/crd/sbomscanner.kubewarden.io_nodescanconfigurations.yaml
@@ -43,6 +43,10 @@ spec:
             description: NodeScanConfigurationSpec defines the desired configuration
               for node scanning.
             properties:
+              enabled:
+                default: true
+                description: Enabled controls whether node scanning is active.
+                type: boolean
               nodeSelector:
                 description: |-
                   NodeSelector filters which nodes are scanned.
@@ -130,6 +134,8 @@ spec:
                 items:
                   type: string
                 type: array
+            required:
+            - enabled
             type: object
         type: object
         x-kubernetes-validations:

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -365,6 +365,13 @@ func main() {
 			os.Exit(1)
 		}
 
+		if err = (&controller.NodeScanConfigurationReconciler{
+			Client: mgr.GetClient(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "NodeScanConfiguration")
+			os.Exit(1)
+		}
+
 		if err = (&controller.NodeScanJobReconciler{
 			Client:    mgr.GetClient(),
 			Scheme:    mgr.GetScheme(),

--- a/docs/crds/CRD-docs-for-docs-repo.adoc
+++ b/docs/crds/CRD-docs-for-docs-repo.adoc
@@ -138,6 +138,7 @@ NodeScanConfigurationSpec defines the desired configuration for node scanning.
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
+| *`enabled`* __boolean__ | Enabled controls whether node scanning is active. + | true | 
 | *`nodeSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta[$$LabelSelector$$]__ | NodeSelector filters which nodes are scanned. +
 If not specified, all the nodes are scanned. + |  | Optional: \{} +
 

--- a/docs/crds/CRD-docs-for-docs-repo.md
+++ b/docs/crds/CRD-docs-for-docs-repo.md
@@ -112,6 +112,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled controls whether node scanning is active. | true |  |
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta)_ | NodeSelector filters which nodes are scanned.<br />If not specified, all the nodes are scanned. |  | Optional: \{\} <br /> |
 | `scanInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#duration-v1-meta)_ | ScanInterval is the interval at which nodes are scanned. |  | Optional: \{\} <br /> |
 | `skipPatterns` _string array_ | SkipPatterns specifies gitignore-style patterns for directories and files to skip during node scanning.<br />Patterns ending with "/" are treated as directories.<br />All other patterns are treated as files.<br />Glob patterns like "**/vendor/" or "*.min.js" are supported. |  | Optional: \{\} <br /> |

--- a/internal/controller/nodescan_controller.go
+++ b/internal/controller/nodescan_controller.go
@@ -47,17 +47,36 @@ func (r *NodeScanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
+// cleanupNodeResources deletes every NodeScanJob and NodeSBOM tied to nodeName.
+//
+// We use List+Delete via the cached field indexes (see internal/controller/indexer.go)
+// rather than DeleteAllOf, because DeleteAllOf bypasses the cache and issues a
+// deletecollection call directly against the API server.
 func (r *NodeScanReconciler) cleanupNodeResources(ctx context.Context, nodeName string) error {
-	if err := r.DeleteAllOf(ctx, &v1alpha1.NodeScanJob{},
+	var nodeScanJobs v1alpha1.NodeScanJobList
+	if err := r.List(ctx, &nodeScanJobs,
 		client.MatchingFields{v1alpha1.IndexNodeScanJobSpecNodeName: nodeName},
-	); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("delete NodeScanJobs for node %s: %w", nodeName, err)
+	); err != nil {
+		return fmt.Errorf("list NodeScanJobs for node %s: %w", nodeName, err)
+	}
+	for i := range nodeScanJobs.Items {
+		job := &nodeScanJobs.Items[i]
+		if err := r.Delete(ctx, job); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete NodeScanJob %s: %w", job.Name, err)
+		}
 	}
 
-	if err := r.DeleteAllOf(ctx, &storagev1alpha1.NodeSBOM{},
+	var nodeSBOMs storagev1alpha1.NodeSBOMList
+	if err := r.List(ctx, &nodeSBOMs,
 		client.MatchingFields{storagev1alpha1.IndexNodeMetadataName: nodeName},
-	); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("delete NodeSBOMs for node %s: %w", nodeName, err)
+	); err != nil {
+		return fmt.Errorf("list NodeSBOMs for node %s: %w", nodeName, err)
+	}
+	for i := range nodeSBOMs.Items {
+		sbom := &nodeSBOMs.Items[i]
+		if err := r.Delete(ctx, sbom); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete NodeSBOM %s: %w", sbom.Name, err)
+		}
 	}
 
 	return nil

--- a/internal/controller/nodescan_runner.go
+++ b/internal/controller/nodescan_runner.go
@@ -69,6 +69,11 @@ func (r *NodeScanRunner) scanNodes(ctx context.Context) error {
 		return fmt.Errorf("failed to get NodeScanConfiguration: %w", err)
 	}
 
+	if !config.Spec.Enabled {
+		log.V(1).Info("NodeScanConfiguration disabled, skipping node scan cycle")
+		return nil
+	}
+
 	rescanRequested := hasForceNodeScanAnnotation(&config)
 
 	nodes, err := r.getMatchingNodes(ctx, &config)

--- a/internal/controller/nodescan_runner_test.go
+++ b/internal/controller/nodescan_runner_test.go
@@ -48,6 +48,7 @@ var _ = Describe("NodeScanRunner", func() {
 						Name: v1alpha1.NodeScanConfigurationName,
 					},
 					Spec: v1alpha1.NodeScanConfigurationSpec{
+						Enabled:      true,
 						ScanInterval: &metav1.Duration{Duration: 1 * time.Hour},
 					},
 				}
@@ -99,6 +100,7 @@ var _ = Describe("NodeScanRunner", func() {
 						Name: v1alpha1.NodeScanConfigurationName,
 					},
 					Spec: v1alpha1.NodeScanConfigurationSpec{
+						Enabled:      true,
 						ScanInterval: &metav1.Duration{Duration: 1 * time.Hour},
 						Platforms: []v1alpha1.Platform{
 							{OS: "linux", Architecture: "amd64"},
@@ -145,6 +147,7 @@ var _ = Describe("NodeScanRunner", func() {
 						},
 					},
 					Spec: v1alpha1.NodeScanConfigurationSpec{
+						Enabled:      true,
 						ScanInterval: &metav1.Duration{Duration: 1 * time.Hour},
 					},
 				}
@@ -231,6 +234,7 @@ var _ = Describe("NodeScanRunner", func() {
 						},
 					},
 					Spec: v1alpha1.NodeScanConfigurationSpec{
+						Enabled:      true,
 						ScanInterval: &metav1.Duration{Duration: 0},
 					},
 				}
@@ -276,6 +280,7 @@ var _ = Describe("NodeScanRunner", func() {
 						Name: v1alpha1.NodeScanConfigurationName,
 					},
 					Spec: v1alpha1.NodeScanConfigurationSpec{
+						Enabled:      true,
 						ScanInterval: &metav1.Duration{Duration: 0},
 					},
 				}

--- a/internal/controller/nodescanconfiguration_controller.go
+++ b/internal/controller/nodescanconfiguration_controller.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
+	v1alpha1 "github.com/kubewarden/sbomscanner/api/v1alpha1"
+)
+
+// NodeScanConfigurationReconciler watches the singleton NodeScanConfiguration
+// and cleans up every NodeScanJob and NodeSBOM across the cluster when the
+// configuration is missing or has scanning disabled.
+type NodeScanConfigurationReconciler struct {
+	client.Client
+}
+
+// +kubebuilder:rbac:groups=sbomscanner.kubewarden.io,resources=nodescanconfigurations,verbs=get;list;watch
+// +kubebuilder:rbac:groups=sbomscanner.kubewarden.io,resources=nodescanjobs,verbs=list;delete;deletecollection
+// +kubebuilder:rbac:groups=storage.sbomscanner.kubewarden.io,resources=nodesboms,verbs=list;watch;delete;deletecollection
+
+func (r *NodeScanConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var config v1alpha1.NodeScanConfiguration
+	if err := r.Get(ctx, req.NamespacedName, &config); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("NodeScanConfiguration not found, cleaning up all node scan resources")
+			if err := r.cleanupAllNodeResources(ctx); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to cleanup all node scan resources: %w", err)
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get NodeScanConfiguration: %w", err)
+	}
+
+	if !config.Spec.Enabled {
+		logger.Info("NodeScanConfiguration disabled, cleaning up all node scan resources")
+		if err := r.cleanupAllNodeResources(ctx); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to cleanup all node scan resources: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// cleanupAllNodeResources deletes every NodeScanJob and NodeSBOM across the cluster.
+// Both resources are cluster-scoped, so an unscoped DeleteAllOf removes all instances.
+func (r *NodeScanConfigurationReconciler) cleanupAllNodeResources(ctx context.Context) error {
+	if err := r.DeleteAllOf(ctx, &v1alpha1.NodeScanJob{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete all NodeScanJobs: %w", err)
+	}
+
+	if err := r.DeleteAllOf(ctx, &storagev1alpha1.NodeSBOM{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete all NodeSBOMs: %w", err)
+	}
+
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NodeScanConfigurationReconciler) SetupWithManager(manager ctrl.Manager) error {
+	err := ctrl.NewControllerManagedBy(manager).
+		Named("nodescanconfiguration-controller").
+		For(&v1alpha1.NodeScanConfiguration{}).
+		Complete(r)
+	if err != nil {
+		return fmt.Errorf("failed to create nodescanconfiguration controller: %w", err)
+	}
+	return nil
+}

--- a/internal/controller/nodescanconfiguration_controller_test.go
+++ b/internal/controller/nodescanconfiguration_controller_test.go
@@ -1,0 +1,202 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kubewarden/sbomscanner/api"
+	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
+	"github.com/kubewarden/sbomscanner/api/v1alpha1"
+)
+
+var _ = Describe("NodeScanConfiguration Controller", func() {
+	configRequest := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.NodeScanConfigurationName},
+	}
+
+	When("the configuration is disabled", func() {
+		var reconciler NodeScanConfigurationReconciler
+		var configuration *v1alpha1.NodeScanConfiguration
+
+		BeforeEach(func(ctx context.Context) {
+			reconciler = NodeScanConfigurationReconciler{Client: k8sClient}
+
+			By("Creating a disabled NodeScanConfiguration")
+			configuration = &v1alpha1.NodeScanConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.NodeScanConfigurationName,
+				},
+				Spec: v1alpha1.NodeScanConfigurationSpec{
+					Enabled: false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, configuration)).To(Succeed())
+		})
+
+		AfterEach(func(ctx context.Context) {
+			By("Deleting the NodeScanConfiguration")
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, configuration))).To(Succeed())
+		})
+
+		It("should cleanup all NodeScanJobs and NodeSBOMs across the cluster", func(ctx context.Context) {
+			By("Seeding NodeScanJobs and NodeSBOMs for two different nodes")
+			nodeA := fmt.Sprintf("node-a-%s", uuid.New().String())
+			nodeB := fmt.Sprintf("node-b-%s", uuid.New().String())
+
+			jobA := v1alpha1.NodeScanJob{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("nodescanjob-%s", nodeA)},
+				Spec:       v1alpha1.NodeScanJobSpec{NodeName: nodeA},
+			}
+			jobB := v1alpha1.NodeScanJob{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("nodescanjob-%s", nodeB)},
+				Spec:       v1alpha1.NodeScanJobSpec{NodeName: nodeB},
+			}
+			Expect(k8sClient.Create(ctx, &jobA)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &jobB)).To(Succeed())
+
+			sbomA := storagev1alpha1.NodeSBOM{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeA,
+					Labels: map[string]string{api.LabelManagedByKey: api.LabelManagedByValue},
+				},
+				NodeMetadata: storagev1alpha1.NodeMetadata{Name: nodeA, Platform: "linux/amd64"},
+				SPDX:         runtime.RawExtension{Raw: []byte("{}")},
+			}
+			sbomB := storagev1alpha1.NodeSBOM{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeB,
+					Labels: map[string]string{api.LabelManagedByKey: api.LabelManagedByValue},
+				},
+				NodeMetadata: storagev1alpha1.NodeMetadata{Name: nodeB, Platform: "linux/amd64"},
+				SPDX:         runtime.RawExtension{Raw: []byte("{}")},
+			}
+			Expect(k8sClient.Create(ctx, &sbomA)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &sbomB)).To(Succeed())
+
+			By("Reconciling the disabled configuration")
+			_, err := reconciler.Reconcile(ctx, configRequest)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying all NodeScanJobs are gone")
+			var jobs v1alpha1.NodeScanJobList
+			Expect(k8sClient.List(ctx, &jobs)).To(Succeed())
+			Expect(jobs.Items).To(BeEmpty())
+
+			By("Verifying all NodeSBOMs are gone")
+			var sboms storagev1alpha1.NodeSBOMList
+			Expect(k8sClient.List(ctx, &sboms)).To(Succeed())
+			Expect(sboms.Items).To(BeEmpty())
+		})
+	})
+
+	When("the configuration does not exist", func() {
+		var reconciler NodeScanConfigurationReconciler
+
+		BeforeEach(func() {
+			reconciler = NodeScanConfigurationReconciler{Client: k8sClient}
+		})
+
+		It("should cleanup all NodeScanJobs and NodeSBOMs across the cluster", func(ctx context.Context) {
+			By("Seeding a NodeScanJob and a NodeSBOM")
+			nodeName := fmt.Sprintf("node-%s", uuid.New().String())
+			job := v1alpha1.NodeScanJob{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("nodescanjob-%s", nodeName)},
+				Spec:       v1alpha1.NodeScanJobSpec{NodeName: nodeName},
+			}
+			Expect(k8sClient.Create(ctx, &job)).To(Succeed())
+
+			sbom := storagev1alpha1.NodeSBOM{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{api.LabelManagedByKey: api.LabelManagedByValue},
+				},
+				NodeMetadata: storagev1alpha1.NodeMetadata{Name: nodeName, Platform: "linux/amd64"},
+				SPDX:         runtime.RawExtension{Raw: []byte("{}")},
+			}
+			Expect(k8sClient.Create(ctx, &sbom)).To(Succeed())
+
+			By("Reconciling the missing configuration")
+			_, err := reconciler.Reconcile(ctx, configRequest)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying all NodeScanJobs are gone")
+			var jobs v1alpha1.NodeScanJobList
+			Expect(k8sClient.List(ctx, &jobs)).To(Succeed())
+			Expect(jobs.Items).To(BeEmpty())
+
+			By("Verifying all NodeSBOMs are gone")
+			var sboms storagev1alpha1.NodeSBOMList
+			Expect(k8sClient.List(ctx, &sboms)).To(Succeed())
+			Expect(sboms.Items).To(BeEmpty())
+		})
+	})
+
+	When("the configuration is enabled", func() {
+		var reconciler NodeScanConfigurationReconciler
+		var configuration *v1alpha1.NodeScanConfiguration
+
+		BeforeEach(func(ctx context.Context) {
+			reconciler = NodeScanConfigurationReconciler{Client: k8sClient}
+
+			By("Creating an enabled NodeScanConfiguration")
+			configuration = &v1alpha1.NodeScanConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.NodeScanConfigurationName,
+				},
+				Spec: v1alpha1.NodeScanConfigurationSpec{
+					Enabled: true,
+				},
+			}
+			Expect(k8sClient.Create(ctx, configuration)).To(Succeed())
+		})
+
+		AfterEach(func(ctx context.Context) {
+			By("Deleting the NodeScanConfiguration")
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, configuration))).To(Succeed())
+		})
+
+		It("should not delete any NodeScanJobs or NodeSBOMs", func(ctx context.Context) {
+			By("Seeding a NodeScanJob and a NodeSBOM")
+			nodeName := fmt.Sprintf("node-%s", uuid.New().String())
+			job := v1alpha1.NodeScanJob{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("nodescanjob-%s", nodeName)},
+				Spec:       v1alpha1.NodeScanJobSpec{NodeName: nodeName},
+			}
+			Expect(k8sClient.Create(ctx, &job)).To(Succeed())
+
+			sbom := storagev1alpha1.NodeSBOM{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{api.LabelManagedByKey: api.LabelManagedByValue},
+				},
+				NodeMetadata: storagev1alpha1.NodeMetadata{Name: nodeName, Platform: "linux/amd64"},
+				SPDX:         runtime.RawExtension{Raw: []byte("{}")},
+			}
+			Expect(k8sClient.Create(ctx, &sbom)).To(Succeed())
+
+			By("Reconciling the enabled configuration")
+			_, err := reconciler.Reconcile(ctx, configRequest)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the seeded NodeScanJob still exists")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name}, &v1alpha1.NodeScanJob{})).To(Succeed())
+
+			By("Verifying the seeded NodeSBOM still exists")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbom.Name}, &storagev1alpha1.NodeSBOM{})).To(Succeed())
+
+			By("Cleaning up the seeded resources")
+			Expect(k8sClient.Delete(ctx, &job)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, &sbom)).To(Succeed())
+		})
+	})
+})

--- a/test/e2e/nodescan_test.go
+++ b/test/e2e/nodescan_test.go
@@ -35,6 +35,7 @@ func TestNodeScan(t *testing.T) {
 					},
 				},
 				Spec: v1alpha1.NodeScanConfigurationSpec{
+					Enabled: true,
 					SkipPatterns: []string{
 						// Exclude containerd runtime files since they
 						// can cause issues with file access and are not
@@ -132,6 +133,39 @@ func TestNodeScan(t *testing.T) {
 
 			return ctx
 		}).
+		Assess("Disable NodeScanConfiguration and verify cleanup", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			nodeScanConfig := &v1alpha1.NodeScanConfiguration{}
+			err := cfg.Client().Resources().Get(ctx, v1alpha1.NodeScanConfigurationName, "", nodeScanConfig)
+			require.NoError(t, err)
+
+			nodeScanConfig.Spec.Enabled = false
+			err = cfg.Client().Resources().Update(ctx, nodeScanConfig)
+			require.NoError(t, err, "failed to disable NodeScanConfiguration")
+
+			err = wait.For(func(ctx context.Context) (bool, error) {
+				jobs := &v1alpha1.NodeScanJobList{}
+				if err := cfg.Client().Resources().List(ctx, jobs,
+					resources.WithLabelSelector(nodeScanLabelSelector),
+				); err != nil {
+					return false, err
+				}
+				return len(jobs.Items) == 0, nil
+			}, wait.WithTimeout(scanTimeout))
+			require.NoError(t, err, "NodeScanJobs should be cleaned up after disabling NodeScanConfiguration")
+
+			err = wait.For(func(ctx context.Context) (bool, error) {
+				sboms := &storagev1alpha1.NodeSBOMList{}
+				if err := cfg.Client().Resources().List(ctx, sboms,
+					resources.WithLabelSelector(nodeScanLabelSelector),
+				); err != nil {
+					return false, err
+				}
+				return len(sboms.Items) == 0, nil
+			}, wait.WithTimeout(scanTimeout))
+			require.NoError(t, err, "NodeSBOMs should be cleaned up after disabling NodeScanConfiguration")
+
+			return ctx
+		}).
 		Assess("Delete NodeScanConfiguration and verify cleanup", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			nodeScanConfig := &v1alpha1.NodeScanConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
@@ -172,6 +206,7 @@ func TestNodeScan(t *testing.T) {
 					Name: v1alpha1.NodeScanConfigurationName,
 				},
 				Spec: v1alpha1.NodeScanConfigurationSpec{
+					Enabled: true,
 					NodeSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"non-existent-label": "no-match",


### PR DESCRIPTION
## Description
- Adds enabled/disabled to NodeScanConfiguration
- Fixes `DeleteAllOf` not working with cache indexes in NodeScan controller


Fixes #1179 