### PR TITLE
feat(charts)helm nodescan toggle

### DIFF
--- a/charts/sbomscanner/templates/controller/deployment.yaml
+++ b/charts/sbomscanner/templates/controller/deployment.yaml
@@ -59,6 +59,9 @@ spec:
             {{- if not .Values.controller.workloadScan.enabled }}
             - -workloadscan=false
             {{- end }}
+            {{- if not .Values.controller.nodeScan.enabled }}
+            - -nodescan=false
+            {{- end }}
           image: '{{ template "system_default_registry" . }}{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}'
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           name: controller

--- a/charts/sbomscanner/templates/worker/daemonset.yaml
+++ b/charts/sbomscanner/templates/worker/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.nodeScan.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -107,3 +108,4 @@ spec:
         - name: nats-tls
           secret:
             secretName: {{ include "sbomscanner.fullname" . }}-nats-worker-client-tls
+{{- end }}

--- a/charts/sbomscanner/templates/worker/node-role.yaml
+++ b/charts/sbomscanner/templates/worker/node-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.nodeScan.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -45,3 +46,4 @@ rules:
       - nodes
     verbs:
       - get
+{{- end }}

--- a/charts/sbomscanner/templates/worker/node-rolebinding.yaml
+++ b/charts/sbomscanner/templates/worker/node-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.nodeScan.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "sbomscanner.fullname" . }}-worker-node
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/sbomscanner/templates/worker/node-serviceaccount.yaml
+++ b/charts/sbomscanner/templates/worker/node-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.nodeScan.enabled }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -6,3 +7,4 @@ metadata:
   labels:
     {{ include "sbomscanner.labels" .| nindent 4 }}
     app.kubernetes.io/component: worker-node
+{{- end }}

--- a/charts/sbomscanner/tests/controller/deployment_test.yaml
+++ b/charts/sbomscanner/tests/controller/deployment_test.yaml
@@ -47,3 +47,32 @@ tests:
           path: "spec.template.spec.containers[0].resources.requests.memory"
           value: "200Mi"
 
+  - it: "should not pass scan toggle args by default"
+    asserts:
+      - notContains:
+          path: "spec.template.spec.containers[0].args"
+          content: "-workloadscan=false"
+      - notContains:
+          path: "spec.template.spec.containers[0].args"
+          content: "-nodescan=false"
+
+  - it: "should disable workloadscan when controller.workloadScan.enabled is false"
+    set:
+      controller:
+        workloadScan:
+          enabled: false
+    asserts:
+      - contains:
+          path: "spec.template.spec.containers[0].args"
+          content: "-workloadscan=false"
+
+  - it: "should disable nodescan when controller.nodeScan.enabled is false"
+    set:
+      controller:
+        nodeScan:
+          enabled: false
+    asserts:
+      - contains:
+          path: "spec.template.spec.containers[0].args"
+          content: "-nodescan=false"
+

--- a/charts/sbomscanner/tests/worker/daemonset_test.yaml
+++ b/charts/sbomscanner/tests/worker/daemonset_test.yaml
@@ -1,0 +1,17 @@
+suite: "Worker DaemonSet Tests"
+templates:
+  - "templates/worker/daemonset.yaml"
+tests:
+  - it: "should render the DaemonSet by default"
+    asserts:
+      - isKind:
+          of: DaemonSet
+
+  - it: "should not render the DaemonSet when controller.nodeScan.enabled is false"
+    set:
+      controller:
+        nodeScan:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/sbomscanner/values.schema.json
+++ b/charts/sbomscanner/values.schema.json
@@ -25,6 +25,14 @@
                 "logLevel": {
                     "type": "string"
                 },
+                "nodeScan": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "pprof": {
                     "type": "boolean"
                 },

--- a/charts/sbomscanner/values.yaml
+++ b/charts/sbomscanner/values.yaml
@@ -26,6 +26,8 @@ controller:
   pprof: false
   workloadScan:
     enabled: true
+  nodeScan:
+    enabled: true
   # Seed default VEXHub resources (rancher, aquasecurity) on chart install.
   # Created via a post-install hook and not tracked by Helm afterwards, so
   # users can freely edit, disable, or delete them.

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -280,7 +280,6 @@ func main() {
 		}
 	}
 
-	//nolint: nestif // The node scan controllers and webhook are related and should be grouped together
 	if cfg.NodeScan {
 		if err = (&controller.NodeScanRunner{
 			Client: mgr.GetClient(),
@@ -312,16 +311,16 @@ func main() {
 			setupLog.Error(err, "unable to create controller", "controller", "NodeScanJob")
 			os.Exit(1)
 		}
+	}
 
-		if err = webhookv1alpha1.SetupNodeScanConfigurationWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "NodeScanConfiguration")
-			os.Exit(1)
-		}
+	if err = webhookv1alpha1.SetupNodeScanConfigurationWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "NodeScanConfiguration")
+		os.Exit(1)
+	}
 
-		if err = webhookv1alpha1.SetupNodeScanJobWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "NodeScanJob")
-			os.Exit(1)
-		}
+	if err = webhookv1alpha1.SetupNodeScanJobWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "NodeScanJob")
+		os.Exit(1)
 	}
 
 	if err = webhookv1alpha1.SetupRegistryWebhookWithManager(mgr, cfg.ServiceAccountNamespace, cfg.ServiceAccountName); err != nil {


### PR DESCRIPTION
## Description

Expose a node scan toggle in the Helm chart. When disabled, the node scan reconcilers are turned off entirely and the worker-node DaemonSet is not deployed, while CRDs and validating webhooks remain in place.