### PR TITLE
docs: correct the platforms in node_scan rfc

### DIFF
--- a/docs/rfc/0008_node_scan.md
+++ b/docs/rfc/0008_node_scan.md
@@ -128,8 +128,10 @@ spec:
         values:
           - k3d-second-node-0
   platforms:
-    - linux/amd64
-    - linux/arm64
+    - arch: "amd64"
+      os: "linux"
+    - arch: "arm64"
+      os: "linux"
 ```
 
 * `NodeScanJob`: Represents a single execution of a node scan.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
If applying node scan rfc's NodeScanConfiguration, then it will show below error. This PR is to correct it.
```text
The NodeScanConfiguration "default" is invalid: 
* spec.platforms[0]: Invalid value: "string": spec.platforms[0] in body must be of type object: "string"
* spec.platforms[1]: Invalid value: "string": spec.platforms[1] in body must be of type object: "string"
```


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
