### PR TITLE
docs(rfc): update node scan rfc with webhook behaviour

### DIFF
--- a/docs/rfc/0008_node_scan.md
+++ b/docs/rfc/0008_node_scan.md
@@ -189,6 +189,24 @@ If another job is already active, the new job is not created.
 
 ![NodeScanConfiguration and NodeScanJob relationship](./assets/nodescanconfig.png)
 
+## Webhook Validation
+
+The `nodeSelector` and `platform` filters defined in the `NodeScanConfiguration`
+do not trigger the execution of a manually created `NodeScanJob` for a node that
+does not match them.
+
+In most cases, this is enforced by a validating webhook: when a user creates a
+`NodeScanJob`, the webhook checks the target node against the current
+`NodeScanConfiguration` `nodeSelector` and `platform` filters and rejects the
+request if the node does not match.
+
+However, the webhook is not the only line of defense. In case a request reaches
+the controller anyway (e.g., the webhook is bypassed or unavailable, or the node
+stopped matching between admission and reconciliation), the controller performs
+an additional validation check. If the node no longer matches the
+`NodeScanConfiguration`, the controller sets the `NodeScanJob` status to
+`NodeNotMatching`.
+
 ## Reconcilers
 
 The NodeScan reconciler is responsible for creating `NodeScanJob` resources based on the 

--- a/docs/rfc/0008_node_scan.md
+++ b/docs/rfc/0008_node_scan.md
@@ -197,15 +197,15 @@ against a node that does not match them.
 
 In most cases, this is enforced by a validating webhook: when a user creates a
 `NodeScanJob`, the webhook checks the target node against the current
-`NodeScanConfiguration` `nodeSelector` and `platform` filters and rejects the
+`NodeScanConfiguration` `nodeSelector` and `platforms` filters and rejects the
 request if the node does not match.
 
 However, the webhook is not the only line of defense. In case a request reaches
 the controller anyway (e.g., the webhook is bypassed or unavailable, or the node
 stopped matching between admission and reconciliation), the controller performs
 an additional validation check. If the node no longer matches the
-`NodeScanConfiguration`, the controller sets the `NodeScanJob` status to
-`NodeNotMatching`.
+`NodeScanConfiguration`, the controller marks the `NodeScanJob` as failed with
+reason `NodeNotMatching`.
 
 ## Reconcilers
 

--- a/docs/rfc/0008_node_scan.md
+++ b/docs/rfc/0008_node_scan.md
@@ -191,9 +191,9 @@ If another job is already active, the new job is not created.
 
 ## Webhook Validation
 
-The `nodeSelector` and `platform` filters defined in the `NodeScanConfiguration`
-do not trigger the execution of a manually created `NodeScanJob` for a node that
-does not match them.
+The `nodeSelector` and `platforms` filters defined in the `NodeScanConfiguration`
+are enforced for manually created `NodeScanJob` resources, so users cannot run a scan
+against a node that does not match them.
 
 In most cases, this is enforced by a validating webhook: when a user creates a
 `NodeScanJob`, the webhook checks the target node against the current


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
During node scan feature we took some decisions that haven't been reported on the RFC.
This PR adds the missing content of node scan webhook behaviour.
This is important because it helps the user to understand the flow when running manual `NodeScanJobs`.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
